### PR TITLE
Cleanup bern

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -13,3 +13,5 @@ theories/ssr_descartes/square_free.v
 theories/ssr_descartes/three_circles.v
 
 -R theories trajectories
+-arg -w -arg -notation-overridden
+-arg -w -arg -ambiguous-paths

--- a/theories/ssr_descartes/bern.v
+++ b/theories/ssr_descartes/bern.v
@@ -1,11 +1,13 @@
-(*Require Import QArith ZArith Zwf Omega.*)
+From mathcomp Require Import all_ssreflect all_algebra.
+(*Require Import QArith ZArith Zwf Omega.
 From mathcomp Require Import ssreflect eqtype ssrbool ssrnat div fintype seq ssrfun order.
 From mathcomp Require Import bigop fingroup choice binomial poly.
-From mathcomp Require Export ssralg rat ssrnum.
-Require Import infra pol civt desc.
+From mathcomp Require Export ssralg rat ssrnum. *)
+Require Import pol desc.
+(* Require Import infra pol civt desc. *)
 
-Import GroupScope .
-Import Order.Theory GRing.Theory Num.Theory.
+(* Import GroupScope . *)
+Import Order.TTheory GRing.Theory Num.Theory.
 Local Open Scope ring_scope .
 
 (* Set Printing Width 50. *)
@@ -183,39 +185,66 @@ suff cmp : eps / 2%:R < eps by [].
 by rewrite ltr_pdivr_mulr// ?ltr0n// ltr_pmulr// ltr1n.
 Qed.
 
-Lemma cm3 {R : archiFieldType} :
+Lemma ler_horner_norm_pol
+  {R : realFieldType} (l : {poly R}) x : (0 <= x)%R ->
+  `|l.[x]| <= \sum_(i < size l) (`|l`_i| * x ^+ i).
+Proof.
+move=> xge0.
+elim/poly_ind: l => [ | l a Ih].
+  by rewrite !hornerE normr0 size_poly0 big_ord0.
+rewrite hornerE.
+have [/eqP -> | ln0] := boolP (l == 0%R).
+  rewrite mul0r !hornerE; rewrite size_polyC.
+  have [/eqP -> | an0] := boolP (a == 0%R); first by rewrite normr0 big_ord0.
+  by rewrite big_ord1 /= expr0 mulr1 coefC eqxx.
+rewrite size_MXaddC (negbTE ln0) /= big_ord_recl expr0 mulr1.
+apply: (le_trans (ler_norm_add _ _)).
+rewrite coefD coefMX eqxx add0r coefC eqxx hornerE [X in X <= _]addrC.
+apply ler_add; first by apply: lexx.
+rewrite !hornerE.
+have exteq : (forall i : 'I_(size l), true ->
+                `|(l * 'X + a%:P)`_(lift ord0 i)| * x ^+ lift ord0 i 
+                = (`|l`_i| * x ^+ i) * x ).
+  move=> i _; rewrite lift0 coefD coefC /= addr0 coefMX /=.
+  by rewrite exprS (mulrC x) mulrA.
+rewrite normrM (ger0_norm xge0).
+by rewrite (eq_bigr _ exteq) -mulr_suml ler_wpmul2r.
+Qed.
+
+Lemma cm3 {R : realFieldType} :
   forall b : R, (0 < b)%R -> forall l : {poly R},
    {c | forall x y : R, (0 <= x)%R -> (x <= y)%R -> (y <= b)%R ->
     `|(l.[y] - l.[x])| <= c * (y - x)}.
 Proof.
-(*move=> b pb; elim=> [|u l [c cp]] /=.
-  by exists 0 => x y; rewrite subrr absr0 mul0r lerr.
-exists ((eval_pol (abs_pol l) b) + c * b) => x y px hxy hyb.
-rewrite addrAC oppr_add addrA subrr add0r addrC.
-set el := eval_pol l in cp *.
-rewrite (_ : y *_ - _ = y * el y - x * el y + x * el y - x * el x); last first.
-  by rewrite -[_ - _ + _]addrA addNr addr0.
-have py : 0 <= y by rewrite (ler_trans px).
-have psyx : 0 <= y - x by rewrite lter_subrA /= add0r.
-rewrite -addrA; apply: (ler_trans (absr_add_le _ _)).
-rewrite -mulNr -mulr_addl -mulrN -mulr_addr !absf_mul (ger0_abs px).
-rewrite (ger0_abs psyx) [_ * (y - x)]mulr_addl; apply: lter_add=> /=.
-(*rewrite absr_nneg // [_ * (y - x)]mulr_addl; apply: lerT.*)
-  rewrite mulrC lter_mulpr //=; apply: (ler_trans (ler_absr_eval_pol l y)).
-  by rewrite eval_pol_abs_pol_increase // ?absrpos // ger0_abs.
-rewrite (mulrC c); apply ler_trans with (x * c * (y - x)).
-  by rewrite -mulrA lter_mulpl //= cp.
-rewrite -!mulrA lter_mulpr //= ?(ler_trans hxy) //.
-by apply: ler_trans (cp _ _ px hxy hyb); apply: absr_ge0.
-Qed.*) Admitted.
+move=> b pb; elim/poly_ind=> [ | l u [c cp]].
+  by exists 0%R => x y; rewrite !hornerE oppr0 normr0 lexx.
+exists
+   ((\sum_(i < size l) `|nth 0 l i| * b ^+ i) + c * b).
+move=> x y xge0 xy yb.
+rewrite !hornerE addrAC opprD addrA addrNK.
+rewrite [A in `|A|](_ : _ = l.[y] * y - l.[y] * x + l.[y] * x - l.[x] * x);
+  last by rewrite -[_ - _ + _]addrA addNr addr0.
+have py : (0 <= y)%R by rewrite (le_trans xge0).
+have psyx : (0 <= y - x)%R by rewrite subr_ge0.
+rewrite -addrA (le_trans (ler_norm_add _ _)) //.
+rewrite -mulrBr -mulrBl !normrM (ger0_norm xge0) (ger0_norm psyx).
+rewrite [X in _ <= X]mulrDl; apply: ler_add.
+  rewrite ler_wpmul2r //.
+  apply: (le_trans (ler_horner_norm_pol l y py)).
+  apply: ler_sum=> i _.
+  apply: ler_wpmul2l; first by apply: normr_ge0.
+  have /pow_monotone : (0 <= y <= b)%R by rewrite py yb.
+  by move=> /(_ i) /andP[].  
+rewrite mulrAC.
+apply: ler_pmul => //; first by apply: cp.
+by apply: (le_trans xy).
+Qed.
 
 Lemma one_root_reciprocate {R : archiFieldType} :
   forall (l : {poly R}), one_root2 (reciprocal_pol l) 1 -> one_root1 l 0 1.
 Proof.
 move=> l [x1 [k [x1gt1 [kp [neg sl]]]]].
 have x10 : (0 < x1)%R by rewrite (lt_trans _ x1gt1)// ltr01.
-(*have ux1 : GRing.unit x1 by apply/negP; move/eqP => q; rewrite q lterr in x10.*)
-(*have uk: GRing.unit k by apply/negP; move/eqP => q; rewrite q lterr in kp.*)
 set y' := x1 - (reciprocal_pol l).[x1] / k.
 have y'1: x1 < y'.
   rewrite /y' -(ltr_add2l (-x1)) addNr addrA addNr add0r -mulNr.
@@ -234,7 +263,6 @@ have [u' [u1 u'u]] : exists u', (1 <= u' /\ u <= u')%R.
   case cmp: (1 <= u)%R; first by exists u; rewrite lexx cmp.
   by exists 1%R; rewrite lexx; split=> //; rewrite ltW // ltNge cmp.
 have u'0 : (0 < u')%R by apply: lt_le_trans u1.
-(*have u'unit : GRing.unit u' by apply/negP; move/eqP=> q; rewrite q lterr in u'0.*)
 have divu_ltr : forall x : R, (0 <= x)%R -> (x / u' <= x)%R.
   move => x x0.
   rewrite ler_pdivr_mulr//.
@@ -270,7 +298,7 @@ move=> [[a b']].
 rewrite {1}/pair_in_interval.
 move=> /and5P[/and3P[cla ? clb']].
 rewrite /pair_in_interval.
-move=> /and3P[x1a ab b'y' nega posb' ?].
+move=> /and3P[x1a ab b'y' nega posb' bma].
 (*  [a [b' [cla [nega [posb' [clb' [x1a [ab b'y']]]]]]]].*)
 move: (cm3 y y0 (reciprocal_pol l)) => [c cp].
 have a0 : (0 < a)%R by apply: lt_le_trans x1a.
@@ -346,15 +374,8 @@ move => x z bvx xz zav ; rewrite le_eqVlt in xz; move/orP: xz => [xz | xz].
   by rewrite (eqP xz) !addrN mulr0 lexx.
 have x0: (0 < x)%R by apply: lt_trans bvx.
 have z0 : (0 < z)%R by apply: (lt_trans x0).
-(*have ux: GRing.unit x by apply/negP;move/eqP=>q; rewrite q lterr in x0.
-have uz: GRing.unit z by apply/negP;move/eqP=>q; rewrite q lterr in z0.*)
-have invo_rec : forall l, reciprocal_pol (reciprocal_pol l) = l.
-  (*by move => l'; rewrite /reciprocate_pol revK.*) admit.
-rewrite -(invo_rec _ l).
-rewrite (@horner_reciprocal _ _ x) //; last by rewrite unitfE gt_eqF.
-rewrite (@horner_reciprocal _ _ z) //; last by rewrite unitfE gt_eqF.
-rewrite reciprocal_size; last first.
-  admit.
+have := horner_reciprocal1 l (unitf_gt0 x0) => ->.
+have := horner_reciprocal1 l (unitf_gt0 z0) => ->.
 rewrite (_ : _ * _ - _ = (x ^+ (size l - 1) - z ^+ (size l - 1)) *
                      (reciprocal_pol l).[x ^-1] +
                      ((reciprocal_pol l).[x ^-1] -
@@ -373,100 +394,81 @@ have k2p : k2 = (k * x1 ^+ 2 * y ^-1 ^+ (size l - 1)).
   have twop : (0 < (1 + 1))%Q by [].
   by rewrite gt_eqF// ltr0n.
 rewrite (_ : k' = k1 + k2); last by rewrite /k1 /k2 addrA addNr add0r.
+have x1ltvz : x1 < z ^-1.
+  by rewrite (le_lt_trans x1a) // -[a]invrK ltef_pinv ?posrE ?invr_gt0 ?ltW.
 rewrite mulrDl; apply: ler_add; last first.
   have maj' : t3 * y^-1 ^+ (size l - 1) <= t3 * z^+ (size l - 1).
     have maj : y^-1 ^+(size l - 1) <= z ^+ (size l - 1).
       case: (size l - 1)%N => [ | n']; first by rewrite !expr0 lexx.
-      (*rewrite lef_expS2 /=.
-          apply: ltrW(lter_trans _ xz); apply: ler_lte_trans bvx.
-          by apply: ltef_invpp.
-        by apply: ltrW; rewrite invf_gte0.
-      by apply: ltrW.*) admit.
-(*    rewrite lter_mulpl // /t3.
-    apply: lter_le_trans (_ : k * (x^-1 - z^-1) <= _); last first.
-      apply: sl.
-        rewrite -[x1]invrK // ltef_invpp //. 
-          by rewrite invf_gte0.
-        apply: ltrW(lter_le_trans zav _).
-        by apply: ltef_invpp => //.
-      by apply: ltef_invpp.
-    apply: mulr_gte0pp=> /=; first by rewrite ltrW.
-    by rewrite subr_gte0; apply: ltef_invpp=> //=; apply: ltrW.*) admit.
+      have /pow_monotone : (0 <= y ^-1 <= z)%R.
+        rewrite ltW /=; last by rewrite invr_gt0 (lt_trans x10).
+        apply: ltW (le_lt_trans _ xz); apply: ltW (le_lt_trans _ bvx).
+        by rewrite lef_pinv ?posrE.
+      by move=> /(_ n'.+1) /andP[].
+    rewrite lter_pmul2l // /t3.
+    apply: (lt_le_trans _ (_ : k * (x ^-1 - z ^-1) <= _)); last first.
+      apply: sl; first by apply: ltW.
+      by rewrite ltf_pinv.
+    by rewrite mulr_gt0 // subr_gt0 ltf_pinv.
   apply: le_trans maj'; rewrite /t3 k2p mulrAC.
-(*  rewrite ltef_mulpr; last by apply expf_gt0; rewrite invf_gte0.
-  apply: lter_trans (_ : k * (x^-1 - z^-1) <= _).
-    rewrite ![k * _]mulrC mulrAC ltef_mulpr; last by [].
-    rewrite -[x^-1](mulrK uz) -{2}[z^-1](mulrK ux) -(mulrC x) -(mulrC z).
-    rewrite (mulrAC x) -!(mulrA _ (x^-1)) -mulr_subl (mulrC (z - x)).
-    rewrite ltef_mulpr /=; last by rewrite subr_gte0.
-    apply: lter_trans (_ : x1/z <= _).
-      rewrite lter_mulpl //=; first by apply: ltrW.
-      apply: lter_trans x1a _; rewrite -(invrK a); apply: ltef_invpp=> //=; last exact: ltrW.
-      by rewrite invf_gte0.
-    rewrite ltef_mulpr //. 
-      rewrite -[x1]invrK //; apply: ltef_invpp => //.
-        by rewrite invf_gte0.
-      apply: ltrW(lter_trans xz _).
-      by apply: lter_le_trans zav _; apply: ltef_invpp.
-    by rewrite invf_gte0.
-  apply: sl.
-    apply: ltrW(ler_lte_trans x1a _).
-    by rewrite -[a]invrK; apply: ltef_invpp => //; rewrite invf_gte0.
-  by apply: ltef_invpp  => //.*) admit.
+  rewrite lter_pmul2r; last by apply: exprn_gt0; rewrite invr_gt0.
+  apply: ltW (lt_le_trans _ (_ :k * (x ^-1 - z ^-1) <= _)).
+    rewrite ![k * _]mulrC mulrAC lter_pmul2r; last by [].
+    rewrite -[x ^-1](mulrK (unitf_gt0 z0)).
+    rewrite  -[X in _ < _ - X](mulrK (unitf_gt0 x0)) -(mulrC x) -(mulrC z).
+    rewrite (mulrAC x) -!(mulrA _ (x^-1)) -mulrBl (mulrC (z - x)).
+    rewrite lter_pmul2r; last by rewrite subr_gte0.
+    apply: lt_le_trans (_ : x1 / z <= _); first by rewrite lter_pmul2l.
+    rewrite lter_pmul2r; last by rewrite invr_gte0.
+    by apply: ltW (lt_trans x1ltvz _); rewrite ltef_pinv ?posrE.
+  apply: sl; first by apply: ltW.
+  by rewrite ltef_pinv ?posrE.
 rewrite /t1/k1/k' {t2 t3}.
 have xzexp : (x ^+ (size l - 1) <= z ^+ (size l - 1)).
   case sizep : (size l - 1)%N => [ | n'].
     by rewrite !expr0 ltexx.
-(*  by rewrite lef_expS2 //= ltrW.*) admit.
+  have /pow_monotone : (0 <= x <= z)%R.
+    by rewrite !ltW.
+  by move=>/(_ n'.+1)=> /andP[].
 case: (lerP 0 ((reciprocal_pol l).[x^-1])) => sign; last first.
-  (*apply: le_trans (_ : 0 <= _).
-
-    rewrite mulNr lter_oppl oppr0; apply: mulr_ge0pp; last first.
-      by rewrite subr_gte0 /= ltrW.
-    apply: ltrW; exact k'p.
-  apply: mulr_gte0nn.
-    by rewrite subr_lte0.
-  by apply: ltrW.
-*)
-  admit.
+  apply: le_trans (_ : 0 <= _)%R.
+    rewrite mulNr lter_oppl oppr0; apply: mulr_ge0; last first.
+      by rewrite subr_gte0 ltW.
+    exact (ltW k'p).
+  rewrite nmulr_lge0 //.
+  by rewrite subr_lte0.
 rewrite mulNr lter_oppl -mulNr opprB.
 have rpxe : (reciprocal_pol l).[x^-1] <= e.
   apply:le_trans (_ : (reciprocal_pol l).[b] <= _) => /=.
     rewrite -subr_gte0 /= ; apply: le_trans (_ : k * (b - x^-1) <= _).
-      rewrite mulr_ge0//.
+      rewrite mulr_ge0 //.
         exact: ltW.
-      rewrite subr_ge0//.
-      admit.
+      by rewrite subr_ge0 ltW // -(invrK b) ltef_pinv ?posrE.
     apply: sl.
-    rewrite -[x1]invrK //. (*; apply: ltef_invpp => //.
-        by rewrite invf_gte0.
-      by apply: ltrW(lter_le_trans (lter_trans xz zav) _); apply: ltef_invpp.
-    by rewrite -[b]invrK //; apply: ltef_invpp.*) admit.
-    admit.
+      by apply: (ltW (lt_trans x1ltvz _)); rewrite ltef_pinv ?posrE.
+    by rewrite -(invrK b) ltef_pinv ?posrE.
   rewrite -[_ _ b]addr0 -(addrN ((reciprocal_pol l).[b'])) addrA.
   rewrite (addrC (_.[b])) -addrA; apply: le_trans e1e2e.
   apply: ler_add; first by [].
-(*  apply: lter_abs; apply: lter_trans (ltrW clb).
-  by apply: cp; last done; apply: ltrW.*) admit.
+  apply: (le_trans (ler_norm _)).
+  by apply/ltW/(le_lt_trans _ clb)/cp=> //; apply/ltW.
 apply: le_trans (_ : (z^+ (size l - 1) - x ^+ (size l - 1)) * e <= _).
   move: xzexp; rewrite -subr_gte0 le_eqVlt; case/orP=> [xzexp | xzexp] /=.
     by rewrite /= -(eqP xzexp) !mul0r.
-  (*rewrite -mulr_subr mulr_gte0pp //=; first by rewrite subr_gte0 /= ltrW.
-  by rewrite subr_gte0.*) admit.
+  by rewrite lter_pmul2l.
 rewrite [_ * e]mulrC; apply: le_trans (_ : e * (u' * (z - x)) <= _)=> /=.
   rewrite ler_pmul2l//.
   apply: le_trans (_ : u * (z - x) <= _).
     apply: up => //.
       by apply: ltW.
     apply: ltW (lt_trans zav _).
-    (*; rewrite -invr1; apply: ltef_invpp => //.
-    by apply: lter_le_trans x1gt1 _.*) admit.
+    by rewrite invf_lt1 //; by apply: lt_le_trans x1a.
   by rewrite ler_pmul2r// subr_gt0.
 rewrite mulrA.
 rewrite ler_pmul2r// ?subr_gt0//.
 rewrite /e divrK// ?unitfE.
 by rewrite gt_eqF//.
-Admitted.
+Qed.
 
 (* TODO(rei)
 Lemma Bernstein_isolate : forall a b l, a < b ->

--- a/theories/ssr_descartes/desc2.v
+++ b/theories/ssr_descartes/desc2.v
@@ -378,7 +378,7 @@ Lemma coprimep_prod p I l (F: I-> {poly R}):
    (all (fun z => coprimep p (F z)) l) -> coprimep p (\prod_(z <- l) (F z)).
 Proof.
 elim l; first by rewrite big_nil /= coprimep1.
-by move => b m Hrec /andP [ap /Hrec]; rewrite big_cons coprimep_mulr ap => ->.
+by move => b m Hrec /andP [ap /Hrec]; rewrite big_cons coprimepMr ap => ->.
 Qed.
 
 Lemma Gauss_dvdp_prod p (I:eqType) (l: seq I) (F: I-> {poly R}):

--- a/theories/ssr_descartes/pol.v
+++ b/theories/ssr_descartes/pol.v
@@ -389,7 +389,7 @@ Qed.
 
 
 Lemma sum_powers_of_x (n: nat) (x:R):
-  (x-1) * (\sum_(i < n) x^+ i) = x ^+ n -1.
+  (x-1) * (\sum_(i < n) x^+ i) = x ^+ n - 1.
 Proof.
 elim: n => [| n Ihn]. 
   by rewrite big_ord0 expr0 mulr0 subrr.
@@ -1077,7 +1077,7 @@ have ia'_sharp : (ia' < n.+1)%N.
   move: ia'iota; rewrite leq_eqVlt; rewrite size_iota; case/orP=> //.
   move/eqP; case=> abs.
   move: pa'n; rewrite abs (nth_map 0%N) ?size_iota // nth_iota //.
-  rewrite add0n divff ?mulr1 ?pnatr_eq0 // addrCA subrr addr0 => {abs} abs.
+  rewrite add0n divff ?mulr1 ?pnatr_eq0 // addrCA subrr addr0 => {} abs.
   by move: plb; rewrite leNgt abs.
 have b'b : b' <= b.
   rewrite /b'/sl (nth_map 0%N) ?size_iota ?ltnS // nth_iota // add0n.


### PR DESCRIPTION
These commits mostly enforce the change of data structure from lists to polynomials.  In proofs, a lot of the changes also
come from changes of names and idioms between math-comp from the early 2010s to math-comp in the early 2020s.

A noteworthy change is the move from reciprocate_pol to reciprocal_pol, where the first one was involutive, but the latter has to adapt to changes in degree if the coefficients of low degree are null.  However, the lemma horner_reciprocal1 makes the transition rather smooth.

This pull request is not totally complete, because the lemma Bernstein_isolate is commented out.