### PR TITLE
Update convex

### DIFF
--- a/theories/convex.v
+++ b/theories/convex.v
@@ -1,546 +1,171 @@
-From mathcomp Require Import all_ssreflect all_algebra vector reals ereal classical_sets.
+From mathcomp Require Import all_ssreflect all_algebra vector reals ereal classical_sets boolp Rstruct.
+From infotheo Require Import convex Reals_ext.
 Require Import preliminaries.
-From infotheo Require Import convex.
 
-Import Order.POrderTheory Order.TotalTheory GRing.Theory Num.Theory.
+Import Order.POrderTheory Order.TotalTheory GRing.Theory Num.Theory preliminaries.
+Import fdist convex.
 Local Open Scope ring_scope.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Lemma in01 (R : numDomainType) (t : R) :
-  `[0, 1]%classic t -> `[0, 1]%classic (1 - t).
+Section convex.
+Variable (E : convType).
+
+Local Open Scope classical_set_scope.
+Local Open Scope convex_scope.
+
+Definition convex_set_of (A : set E) : is_convex_set A -> {convex_set E}.
+move=>Aconv.
+by exists A; apply CSet.Mixin.
+Defined.
+
+Lemma is_convex_setI (C D : {convex_set E}) : is_convex_set (C `&` D).
 Proof.
-rewrite /= !in_itv/= => /andP[t0 t1].
-by rewrite subr_ge0 t1/= ler_subl_addl ler_addr.
+by apply/asboolP=>x y p [Cx Dx] [Cy Dy]; split; [ move:(convex_setP C) | move:(convex_setP D)]; move=>/asboolP; apply.
 Qed.
 
-(* NB: already exists in MathComp-Analysis (master) *)
-Lemma onemK (R : numDomainType) (r : R) : 1 - (1 - r) = r.
-Proof. by rewrite opprB addrCA subrr addr0. Qed.
+Lemma hullX (F : convType) (C : set E) (D : set F) : hull (C `*` D) = hull C `*` hull D.
+Proof.
+rewrite eqEsubset; split.
+   move=>+ [n][g][d][gCD]-> =>_.
+   rewrite Convn_pair; split=>/=;
+      exists n; [exists (fst \o g) | exists (snd \o g)]; exists d; split=>// + [i] _ <- =>_ /=;
+      (suff: ((C `*` D) (g i)) by move=>[]);
+      by apply gCD; exists i.
+move=>[+ +][]/=[n][g][d][gC->][m][f][e][fD->]=>_ _.
+exists (n * m)%N, (fun i=> let (i, j) := split_prod i in (g i, f j)), (fdistmap (unsplit_prod (n:=m)) (d `x e)%fdist); split.
+   move=>+ [i] _ <- =>_.
+   by case: (split_prod i)=>a b; split; [apply gC | apply fD].
+rewrite Convn_pair/comp/=; congr pair; apply S1_inj; rewrite !S1_Convn big_prod_ord/=.
+   apply eq_big=>// i _.
+   rewrite -(scale1pt (scalept _ _)) scaleptA//.
+   rewrite -(FDist.f1 e).
+   (* TODO: the next 5 lines should be a single rewrite. *)
+   move: (@mulr_suml R_ringType _ (index_enum (ordinal_finType m)) (fun i=> i \in ordinal_finType m) (fun i=> Reals_ext.nneg_ff (FDist.f e) i) (Reals_ext.nneg_ff (FDist.f d) i))=>/=.
+   have->: @GRing.mul R_ringType = Rdefinitions.RbaseSymbolsImpl.Rmult by [].
+   have->: GRing.zero (GRing.Ring.zmodType R_ringType) = Rdefinitions.RbaseSymbolsImpl.R0 by [].
+   have->: (@GRing.add (GRing.Ring.zmodType R_ringType)) = Rdefinitions.RbaseSymbolsImpl.Rplus by [].
+   move=>->.
+   simple refine (let h : Reals_ext.nneg_fun 'I_m := _ in _).
+      exists (fun i0=> Rdefinitions.RbaseSymbolsImpl.Rmult
+        (Reals_ext.nneg_ff (FDist.f e) i0)
+        (Reals_ext.nneg_ff (FDist.f d) i))=>j.
+      by apply ssrR.mulR_ge0; apply FDist.ge0.
+   have->: \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(i0 in 'I_m)
+      Rdefinitions.RbaseSymbolsImpl.Rmult
+        (Reals_ext.nneg_ff (FDist.f e) i0)
+        (Reals_ext.nneg_ff (FDist.f d) i) =
+      \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(i in 'I_m)
+      Reals_ext.nneg_f h i.
+      by apply eq_big=>// j _; rewrite fdist_prodE.
+   rewrite scalept_sum.
+   apply eq_big=>// j _.
+   rewrite/h/= fdistmapE.
+   have->: \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(a in 
+   prod_finType (ordinal_finType n) (ordinal_finType m) | 
+   a
+     \in preim (unsplit_prod (n:=m))
+           (pred1 (Ordinal (unsplit_prodp i j))))
 
-(* NB: similar def and lemmas in set_interval; TODO: generalize? *)
-Section conv.
-Variables (R : realType) (E : lmodType R).
+           Reals_ext.nneg_ff (FDist.f (fdist_prod d (fun=> e))) a =
+      \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(a in 
+   prod_finType (ordinal_finType n) (ordinal_finType m) | 
+   a
+     \in (pred1 (i, j)))
+      Reals_ext.nneg_ff (FDist.f (fdist_prod d (fun=> e))) a.
+      apply eq_big=>// k; congr andb; rewrite 3!inE.
+      by refine (inj_eq _ k (i, j)); exact (can_inj (@unsplit_prodK n m)). 
+   rewrite (big_pred1 (i, j))// fdist_prodE/= ssrR.mulRC; congr (scalept _ (S1 (g _))).
+   by move:(unsplit_prodK (i, j))=>/(congr1 fst)/esym.
+rewrite bigC/=.
+apply eq_big=>// j _.
+rewrite -(scale1pt (scalept _ _)) scaleptA//.
+rewrite -(FDist.f1 d).
+(* TODO: the next 5 lines should be a single rewrite. *)
+move: (@mulr_suml R_ringType _ (index_enum (ordinal_finType n)) (fun i=> i \in ordinal_finType n) (fun i=> Reals_ext.nneg_ff (FDist.f d) i) (Reals_ext.nneg_ff (FDist.f e) j))=>/=.
+have->: @GRing.mul R_ringType = Rdefinitions.RbaseSymbolsImpl.Rmult by [].
+have->: GRing.zero (GRing.Ring.zmodType R_ringType) = Rdefinitions.RbaseSymbolsImpl.R0 by [].
+have->: (@GRing.add (GRing.Ring.zmodType R_ringType)) = Rdefinitions.RbaseSymbolsImpl.Rplus by [].
+move=>->.
+simple refine (let h : Reals_ext.nneg_fun 'I_n := _ in _).
+   exists (fun i=> Rdefinitions.RbaseSymbolsImpl.Rmult
+      (Reals_ext.nneg_ff (FDist.f d) i)
+      (Reals_ext.nneg_ff (FDist.f e) j))=>i.
+   by apply ssrR.mulR_ge0; apply FDist.ge0.
+have->: \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(i in 'I_n)
+   Rdefinitions.RbaseSymbolsImpl.Rmult
+      (Reals_ext.nneg_ff (FDist.f d) i)
+      (Reals_ext.nneg_ff (FDist.f e) j) =
+   \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(i in 'I_n)
+   Reals_ext.nneg_f h i.
+   by apply eq_big=>// i _; rewrite fdist_prodE.
+rewrite scalept_sum.
+apply eq_big=>// i _.
+rewrite/h/= fdistmapE.
+have->: \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(a in 
+   prod_finType (ordinal_finType n) (ordinal_finType m) | 
+   a
+   \in preim (unsplit_prod (n:=m))
+         (pred1 (Ordinal (unsplit_prodp i j))))
 
-Definition conv' (a b : E) t : E := t *: a + (1 - t) *: b.
+         Reals_ext.nneg_ff (FDist.f (fdist_prod d (fun=> e))) a =
+   \big[Rdefinitions.RbaseSymbolsImpl.Rplus/Rdefinitions.RbaseSymbolsImpl.R0]_(a in 
+   prod_finType (ordinal_finType n) (ordinal_finType m) | 
+   a
+     \in (pred1 (i, j)))
+      Reals_ext.nneg_ff (FDist.f (fdist_prod d (fun=> e))) a.
+   apply eq_big=>// k; congr andb; rewrite 3!inE.
+   by refine (inj_eq _ k (i, j)); exact (can_inj (@unsplit_prodK n m)). 
+rewrite (big_pred1 (i, j))// fdist_prodE/= ssrR.mulRC; congr (scalept _ (S1 (f _))).
+by move:(unsplit_prodK (i, j))=>/(congr1 snd)/esym.
+Qed.
 
-Lemma conv'_sym v u r : conv' v u (1 - r) = conv' u v r.
-Proof. by rewrite /conv' onemK addrC. Qed.
+End convex.
 
-Lemma conv'1 x y : conv' x y 1 = x.
-Proof. by rewrite /conv' subrr scale0r scale1r addr0. Qed.
+Lemma add_affine (E : lmodType R_ringType) : affine (fun p : E * E => p.1 + p.2).
+Proof.
+move=>p/= [x0 x1] [y0 y1]/=.
+by rewrite/conv/= addrACA -2!scalerDr.
+Qed.
 
-Lemma conv'0 x y : conv' x y 0 = y.
-Proof. by rewrite /conv' subr0 scale0r scale1r add0r. Qed.
+Lemma scale_affine (E : lmodType R_ringType) (t : Rdefinitions.RbaseSymbolsImpl.R) : affine (fun x : E=> t *: x).
+Proof.
+move=>p/= x y.
+by rewrite/conv/= scalerDr; congr GRing.add; rewrite 2!scalerA mulrC.
+Qed.
 
-Lemma conv'xx x t : conv' x x t = x.
-Proof. by rewrite /conv' -scalerDl addrCA subrr addr0 scale1r. Qed.
-
-End conv.
-
-(* TODO: Remove the module, it is only here to print the results at the end. *)
-Module Convex.
 Section C.
-
-Variable R: realType.
-Variable E: lmodType R.
+Variable E F: lmodType R_ringType.
+Variable f : {linear E -> F}.
 
 Local Open Scope fun_scope.
 Local Open Scope ring_scope.
+Local Open Scope convex_scope.
 
-Definition segment (x y: E) := image `[0: R, 1] (conv' x y).
-
-Lemma segment_sym (u v x : E) : segment u v x -> segment v u x.
+Lemma ker_convex: is_convex_set (preimage f [set 0]).
 Proof.
-by move=> [t t01 <-]; exists (1 - t); rewrite ?conv'_sym//; exact: in01.
-Qed.
-
-Lemma segmentL x y : segment x y x.
-Proof. by exists 1; rewrite ?conv'1// /= in_itv/= ler01 lexx. Qed.
-
-Lemma segmentR x y : segment x y y.
-Proof. by exists 0; rewrite ?conv'0// /= in_itv/= ler01 lexx. Qed.
-
-Definition convex (C: set E) := forall x y, C x -> C y -> subset (segment x y) C.
-
-Lemma segment_convex (x y: E): convex (segment x y).
-Proof.
-move=> x0 y0 [t0 /andP [t00 t01]] <- [t1 /andP [t10 t11]] <- z [t /andP [t0' t1']] <-.
-rewrite /conv'.
-do 2 rewrite scalerDr scalerA scalerA.
-rewrite [_ *: _ + _]addrC addrA addrC -addrA -scalerDl addrA -scalerDl addrC.
-have e: (1 - t) * (1 - t1) + t * (1 - t0) = 1 - (t * t0 + (1 - t) * t1).
-  by rewrite mulrBr mulr1 opprD addrAC addrA mulrDr mulr1 addrA subrK mulrN.
-rewrite e; exists (t * t0 + (1 - t) * t1)=>//.
-apply /andP; split; rewrite bnd_simp.
-  by rewrite addr_ge0// mulr_ge0// subr_ge0.
-by rewrite -subr_ge0 -e addr_ge0// mulr_ge0// subr_ge0.
-Qed.
-
-Lemma convexI (C D: set E): convex C -> convex D -> convex (C `&` D).
-Proof.
-move=> Cc Dc x y [Cx Dx] [Cy Dy] z xzy.
-by split; [ apply (Cc x y) | apply (Dc x y) ].
-Qed.
-
-
-Definition conv (A: set E): set E := fun a: E => exists (s: seq E) (k: 'I_(size s) -> R),
-  [/\ \sum_i k i = 1, \sum_i k i *: s`_i = a, forall i, k i >= 0 & forall i: 'I_(size s), s`_i \in A].
-
-Lemma conv_ext (A: set E): subset A (conv A).
-Proof.
-move=> x Ax.
-exists [:: x], (fun _ => 1); split; rewrite ?big_ord1 ?scale1r ?ler01// => i.
-by rewrite (ord1 i)/= inE.
-Qed.
-
-Lemma conv_sub_convex (A C: set E): subset A C -> convex C -> subset (conv A) C.
-Proof.
-move=>AsC Cc x [s [k [k1 kx k0 kA]]]; subst x.
-remember (size s) as n; move: Heqn=>/esym Heqn.
-elim: n s Heqn k k1 k0 kA=> [| n IHn] s sn k k1 k0 kA.
-   by exfalso; move: (oner_neq0 R)=>/eqP; apply; rewrite -k1 big_ord0.
-case: s sn kA=> // a s sn kA.
-move: k1; (do 2 rewrite big_ord_recl)=>/= k1.
-case t1: (k ord0 == 1).
-move: t1 k1=>/eqP -> /(f_equal (fun x => x-1)); rewrite subrr [1+_]addrC addrK=>/psumr_eq0P.
-   have h: forall i : ordinal_finType n, true -> 0 <= k (lift ord0 i) by move=> i _; apply k0.
-   move=>/(_ h) k0'.
-   rewrite (congr_big _ (fun _ => true) (fun _ => 0 *: 0) Logic.eq_refl)=>//.
-      2: by move=>i _; rewrite (k0' _ Logic.eq_refl) scale0r scale0r.
-   rewrite -scaler_sumr scale0r addr0 scale1r.
-   by apply AsC; move: (kA ord0)=>/set_mem.
-move: k1=>/(f_equal (fun x => x-(k ord0))); rewrite [k ord0 + _]addrC addrK=>k1.
-have k0le1: 0 <= 1 - k ord0.
-   by rewrite -k1; apply sumr_ge0=>i _; apply k0.
-have k0ne1: 1-k ord0 != 0.
-   rewrite subr_eq0; apply /eqP=>k01.
-   by move: t1; rewrite -k01 eq_refl.
-inversion sn.
-apply (Cc a ((GRing.inv (1-(k ord0))) *: \sum_(i < n) k (lift ord0 i) *: s`_i)).
-   by apply AsC; apply set_mem; move: (kA ord0).
-   2:{
-   exists (k ord0).
-      apply /andP; split; rewrite bnd_simp=>//.
-      by rewrite -subr_ge0.
-   by congr GRing.add; rewrite scalerA divff // scale1r.
-   }
-rewrite scaler_sumr.
-move:IHn=>/(_ s H0 (fun i => (1 - k ord0)^-1 * k (lift ord0 i))).
-rewrite -mulr_sumr k1 mulrC=>/(_ (mulfV k0ne1)).
-have k0': forall i : 'I_n, 0 <= (1 - k ord0)^-1 * k (lift ord0 i) by move=> i; apply mulr_ge0=>//; rewrite invr_ge0.
-move=>/(_ k0').
-have kA': forall i : 'I_n, s`_i \in A by move=> i; move: (kA (lift ord0 i)).
-move=>/(_ kA') inC.
-refine (eq_ind _ _ inC _ _); apply congr_big=>// i _.
-by rewrite scalerA.
-Qed.
-
-Lemma conv_segment (x y: E): segment x y = conv [set x; y].
-Proof.
-rewrite eqEsubset; split.
-   move=> z [t /andP [t0 t1]] <-.
-   rewrite bnd_simp in t0; rewrite bnd_simp in t1.
-   exists [:: x; y].
-   exists (fun i => match i with | @Ordinal _ 0 _ => t| _ => 1-t end).
-   split.
-   - by rewrite big_ord_recl big_ord1 -botEord /= [1-t]addrC addrA subrr add0r.
-   - by rewrite big_ord_recl big_ord1 -botEord.
-   - by move=> /= [[]// []]; rewrite subr_ge0.
-   - move=>[i ilt].
-     by apply mem_set; case: i ilt=>[| i] ilt; [ left | right; case: i ilt].
-apply conv_sub_convex; last exact: segment_convex.
-by move=> z [|] ->; [exact: segmentL|exact: segmentR].
-Qed.
-
-Lemma conv_convex (A: set E): convex (conv A).
-Proof.
-move=> x y [sx [kx [kx1 kxx kx0 kxA]]] [sy [ky [ky1 kyy ky0 kyA]]] z [t /andP [t0 t1] tz]; subst x y z.
-rewrite bnd_simp in t0; rewrite bnd_simp in t1.
-exists (sx ++ sy); rewrite size_cat.
-exists (fun i => match split i with | inl i => t * kx i | inr i => (1-t) * ky i end).
-split.
-- rewrite big_split_ord (congr_big _ (fun _ => true) (fun i => t * kx i) Logic.eq_refl) //.
-     2: by move=> i _; rewrite (unsplitK (inl i)).
-  rewrite -mulr_sumr kx1 mulr1 (congr_big _ (fun _ => true) (fun i => (1-t) * ky i) Logic.eq_refl) //.
-     2: by move=> i _; rewrite (unsplitK (inr i)).
-  rewrite -mulr_sumr ky1 mulr1 addrC.
-  have -> : GRing.add_monoid R t (- t + 1) = t + (-t+1) by lazy.
-  by rewrite addrA subrr add0r.
-- rewrite big_split_ord (congr_big _ (fun _ => true) (fun i => t *: (kx i *: sx`_i)) Logic.eq_refl) //.
-    2: by move=> i _; rewrite nth_cat_ord (unsplitK (inl i)) scalerA.
-  rewrite -scaler_sumr (congr_big _ (fun _ => true) (fun i => (1-t) *: (ky i *: sy`_i)) Logic.eq_refl) //.
-    2: by move=> i _; rewrite nth_cat_ord (unsplitK (inr i)) scalerA.
-  by rewrite -scaler_sumr; lazy.
-- by move=> i; case: (split i)=>o; apply mulr_ge0=>//; rewrite subr_ge0.
-- by move=> i; rewrite nth_cat_ord; case: (split _).
-Qed.
-
-Lemma convex_convE (C: set E): convex C <-> C = conv C.
-Proof.
-split=> Cc.
-   by rewrite eqEsubset; split; [ apply conv_ext | apply conv_sub_convex ].
-by rewrite Cc; apply conv_convex.
-Qed.
-
-Lemma conv_mono (A B: set E): subset A B -> subset (conv A) (conv B).
-Proof.
-move=>AB; apply conv_sub_convex.
-   by apply (subset_trans AB), conv_ext.
-by apply conv_convex.
-Qed.
-
-(* TODO: find how to speak about multilinear maps. *)
-Lemma conv_add (A B: set E): conv [set a + b | a in A & b in B] = [set a + b | a in (conv A) & b in (conv B)]%classic.
-Proof.
-rewrite eqEsubset; split.
-   apply conv_sub_convex.
-      by apply image2_subset; apply conv_ext.
-   move=> x y [ax axA [bx bxA xe]] [ay ayA [by' byA ye]] z [t t01 ze]; subst x y z.
-   exists (t *: ax + (1-t) *: ay).
-      by apply (conv_convex axA ayA); exists t.
-   exists (t *: bx + (1-t) *: by').
-      by apply (conv_convex bxA byA); exists t.
-   rewrite /conv'.
-   by rewrite scalerDr scalerDr -addrA -addrA; congr GRing.add; rewrite addrA addrA; congr GRing.add; apply addrC.
-move=> x [a [sa [ka [ka1 kaa ka0 kaA]]] [b [sb [kb [kb1 kbb kb0 kbA]]] xe]]; subst x a b.
-exists ([seq i+j | i <- sa, j <- sb]); rewrite size_allpairs.
-exists (fun i=> let (i, j) := split_prod i in ka i * kb j).
-split.
-- rewrite big_prod_ord -ka1.
-  apply congr_big=>// i _.
-  rewrite -[ka i]mulr1 -kb1 mulr_sumr.
-  apply congr_big=>// j _.
-  by move: (unsplit_prodK (i, j))=>/pair_equal_spec [-> ->].
-- rewrite big_prod_ord.
-  rewrite -[\sum_i kb i *: sb`_i]scale1r -ka1 scaler_suml -big_split.
-  apply congr_big=>// i _.
-  rewrite scaler_sumr -[ka i *: sa`_i]scale1r -kb1 scaler_suml -big_split.
-  apply congr_big=>// j _.
-  by rewrite (nth_allpairs _ 0 0) unsplit_prodK scalerDr scalerA scalerA mulrC//=.
-  move=> i.
-  by case: split_prod=>o o0; apply mulr_ge0.
-- move=> i.
-  rewrite (nth_allpairs _ 0 0); case: split_prod=>o o0.
-  apply mem_set.
-  exists (sa`_o).
-     by apply set_mem.
-  exists (sb`_o0)=>//.
-  by apply set_mem.
-Qed.
-
-Lemma conv_scale (A: set E) (t: R): conv [set t *: a | a in A] = [set t *: a | a in (conv A)]%classic.
-Proof.
-rewrite eqEsubset; split.
-   apply conv_sub_convex.
-      by apply image_subset, conv_ext.
-   move=> tx ty [x xA txe] [y yA tye] z [u u01 ze]; subst tx ty z.
-   exists (u *: x + (1-u) *: y).
-      by apply (conv_convex xA yA); exists u.
-   by rewrite scalerDr; congr GRing.add; rewrite scalerA scalerA mulrC.
-move=> tx [x [s [k [k1 kx k0 kA]]] txe]; subst tx x.
-rewrite scaler_sumr.
-exists [seq t *: a | a <- s].
-rewrite size_map; exists k.
-split=>//.
-- apply congr_big=>// [[i ilt]] _.
-  by rewrite (nth_map 0) // scalerA scalerA mulrC.
-- move=> i.
-  rewrite (nth_map 0) //.
-  apply mem_set; exists (s`_i)=> //.
-  by apply set_mem.
-Qed.
-
-Lemma convexT: convex setT.
-Proof. by []. Qed.
-
-Lemma convex0: convex set0.
-Proof. by []. Qed.
-
-Lemma convex1 x : convex [set x].
-Proof. by move=> u v /= -> -> y [t t01 <-]; rewrite conv'xx. Qed.
-
-End C.
-
-Section C.
-Variable R: realType.
-Variable E F: lmodType R.
-
-Local Open Scope fun_scope.
-Local Open Scope ring_scope.
-
-Variable f: {linear E -> F}.
-
-(* TODO: this lemma is already in infotheo where it was wrongly specialized to R!
-   this will be fixed in infotheo 0.5.1 so that this lemma can be removed *)
-Lemma preimage_add_ker (A: set F) :
-  [set a + b | a in f @^-1` A & b in f @^-1` [set 0]]%classic = (f @^-1` A)%classic.
-Proof.
-rewrite eqEsubset; split.
--  move=> x [a /= aA] [b /= bker] xe; subst x.
-   by rewrite GRing.linearD bker GRing.addr0.
-- move=> x /= fx; exists x=>//.
-  by exists 0; [ apply GRing.linear0 | apply GRing.addr0].
-Qed.
-
-Lemma imset_conv_lin (A: set E): image (conv A) f = conv (image A f).
-Proof.
-rewrite eqEsubset; split.
-   move=> x [y [s [k [k1 ky k0 kA]]] xe]; subst x y.
-   rewrite raddf_sum.
-   exists (map f s); rewrite size_map; exists k.
-   split=>//.
-   - apply congr_big=>// i _.
-     by rewrite (nth_map 0) // -linearZZ.
-   - move=> i; rewrite (nth_map 0) // inE.
-     by exists (s`_i)=>//; apply set_mem.
-apply conv_sub_convex.
-   apply image_subset, conv_ext.
-move=> fx fy [x xA fxe] [y yA fye] z [t t01] ze; subst fx fy z.
-rewrite /conv' /=.
-rewrite -linearZZ -linearZZ -raddfD.
-exists (t *: x + (1-t) *: y)=>//.
-by apply (conv_convex xA yA); exists t.
-Qed.
-
-Lemma preimset_conv_lin_sub (A: set F): subset (conv (preimage f A)) (preimage f (conv A)). 
-Proof.
-move=> x [s [k [k1 kx k0 kA]]]; subst x=>/=; rewrite raddf_sum.
-exists (map f s); rewrite size_map; exists k.
-split=>//.
-- apply congr_big=>// i _.
-  by rewrite (nth_map 0) // -linearZZ.
-- move=> i; rewrite (nth_map 0) //.
-  by apply mem_set; move: (kA i)=>/set_mem.
-Qed.
-
-Lemma ker_convex: convex (preimage f [set 0]).
-Proof.
-move=> x y /= fx0 fy0 z [t t01 ze]; subst z=>/=.
-by rewrite linearD linearZZ linearZZ fx0 fy0 scaler0 scaler0 addr0.
-Qed.
-
-Lemma preimage_conv_linE (A: set F): subset A (range f) -> preimage f (conv A) = conv (preimage f A).
-Proof.
-rewrite eqEsubset; split.
-   2: by apply preimset_conv_lin_sub.
-move=> x [s [k [k1 kx k0 kA]]].
-have: all (fun x => x \in range f) s.
-   apply /allP=>a /(nthP 0) [i ilt <-].
-   apply mem_set, H, set_mem.
-   by move: (kA (Ordinal ilt)).
-move=>/lift_range [s' se]; subst s.
-move: k k0 kx k1 kA; rewrite size_map=>k k0 kx k1 kA.
-rewrite -preimage_add_ker conv_add.
-move: ker_convex=>/convex_convE <-.
-exists (\sum_i k i *: s'`_i).
-   exists s', k; split => //.
-   move=> i; apply mem_set=>/=; apply set_mem.
-   by move: (kA i); rewrite (nth_map 0).
-exists (x - \sum_i k i *: s'`_i)=>/=.
-   rewrite linearD linearN.
-   suff: f x = f (\sum_(i < size s') k i *: s'`_i) by move=>->; rewrite subrr.
-   by rewrite -kx linear_sum; apply congr_big=>// [[t a]] _; rewrite linearZZ (nth_map 0).
-by rewrite addrA [_+x]addrC -addrA subrr addr0.
+apply/asboolP=>x y p /= fx0 fy0.
+by rewrite linearD 2!linearZZ fx0 fy0 2!GRing.scaler0 addr0.
 Qed.
 
 End C.
-
-
-Section vect.
-
-Variable R: realType.
-Variable E: vectType R.
-
-Local Open Scope fun_scope.
-Local Open Scope ring_scope.
-
-(* TODO: excessivement immonde *)
-Lemma caratheodory (A: set E) x: x \in conv A -> exists s: seq E, x \in conv [set` s] /\ (size s <= (dimv (@fullv R E)).+1)%N /\ all (fun x => x \in A) s.
-Proof.
-move=>/set_mem [s [k [k1 kx k0 kA]]]; subst x.
-remember (size s) as n; move: Heqn=>/esym Heqn.
-elim: n s Heqn k k1 k0 kA=> [| n IHn] s ns k k1 k0 kA.
-   exists nil; split=>//.
-   rewrite big_ord0; apply mem_set; exists nil, k; split=>//; rewrite ?big_ord0//.
-   by move=> i; inversion i; move: H; rewrite ltn0.
-case nsgt: (size s <= (dimv (@fullv R E)).+1)%N.
-   exists s; split.
-      apply mem_set; exists s; rewrite ns; exists k; split=>//.
-      by move=> i; apply mem_set; apply mem_nth; rewrite ns.
-   split=>//.
-   by apply /allP=>a /(nthP 0); rewrite ns=> [[i ilt <-]]; move: (kA (Ordinal ilt)).
-have: exists mu: 'I_(size s) -> R, \sum_(i < size s) mu i = 0 /\ \sum_(i < size s) (mu i) *: s`_i = 0 /\ exists i, mu i <> 0.
-   clear IHn.
-   move: nsgt; rewrite ns ltnNge=>/negP/negP nsgt.
-   case: s ns kA=> // a s ns kA; inversion ns; subst n; clear ns.
-   case sf: (free (in_tuple [seq b-a | b <- s])).
-      have: basis_of fullv (in_tuple [seq b-a | b <- s]).
-         rewrite basisEfree; apply /andP; split=>//; apply /andP; split.
-            by apply subvf.
-         rewrite size_map.
-         by refine (leq_trans _ nsgt).
-      rewrite in_tupleE basisEdim size_map=>/andP [_ nsge].
-      by move: nsgt; rewrite ltnNge nsge.
-   move/negbT : sf => /preliminaries.freeN_combination; rewrite in_tupleE size_map=> [[mu [musum [i mui]]]].
-   rewrite /= -addn1 addnC.
-   exists (fun i => match split i with | inl i => - \sum_i mu i | inr i => mu i end).
-   split.
-      rewrite big_split_ord big_ord1 (unsplitK (inl _)).
-      have->: forall n m, GRing.add_monoid R n m = n + m by [].
-      rewrite addrC; apply /eqP; rewrite subr_eq0; apply /eqP.
-      apply congr_big=>// j _.
-      by rewrite (unsplitK (inr _)).
-   split.
-      rewrite big_split_ord big_ord1 (unsplitK (inl _)) /= scaleNr addrC scaler_suml -sumrB -{3}musum.
-      apply congr_big=>// j _.
-      by rewrite (unsplitK (inr _)) (nth_map 0) // scalerBr.
-   by exists (rshift 1 i); rewrite (unsplitK (inr _)); apply /eqP.
-clear nsgt; rewrite ns; move=>[mu [muR [muE [i mui]]]].
-wlog: mu muR muE mui / mu i > 0.
-   move=> H.
-   case mupos: (0 < mu i).
-      by apply (H mu).
-   apply (H (fun i => - mu i)).
-      + by rewrite sumrN muR oppr0.
-      + by rewrite -{3}oppr0 -{3}muE -sumrN; apply congr_big=>// j _; rewrite scaleNr.
-      + by move=> /(f_equal (@GRing.opp R)); rewrite opprK oppr0.
-      + move: mui=>/eqP; rewrite [mu i != 0]real_neqr_lt. move=>/orP; case; [ by rewrite oppr_gt0 | by rewrite mupos ].
-         by apply num_real.
-         by apply num_real.
-move=>/(@arg_minP _ _ _ i (fun i => 0 < mu i) (fun i => (k i) / (mu i))) [im muip muim]; clear i mui.
-wlog: s ns k k1 k0 kA mu muR muE im muip muim / (im == ord0)%N.
-   set f := fun i: nat => if i == nat_of_ord im then 0%N else if i == 0%N then nat_of_ord im else i.
-   have fcan: cancel f f.
-      move=> j; rewrite /f.
-      case jim: (j == im); case j0: (j == 0%N); case im0: (0%N == im); rewrite ?eq_refl; rewrite ?jim ?j0; move: jim j0 im0=>/eqP jim /eqP j0 /eqP im0; try subst j; try subst im =>//; try reflexivity; exact im0.
-   have flt: forall i: 'I_n.+1, (f i < n.+1)%N by move=>[j jlt]; rewrite /f; case jim: (j == im); case j0: (j == 0%N).
-   have fbij: bijective (fun i => Ordinal (flt i)) by exists (fun i => Ordinal (flt i)); move=> [j jlt]; apply val_inj, fcan.
-   move=>/(_ (mkseq (fun i => nth 0 s (f i)) n.+1)); rewrite size_mkseq=>/(_ Logic.eq_refl (fun i => k (Ordinal (flt i)))).
-   have k1': \sum_i k (Ordinal (flt i)) = 1.
-      rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
-      by rewrite big_map -k1; apply congr_big=>// [[j jlt]] _; congr k; apply val_inj, fcan.
-   move=> /(_ k1').
-   have k0': forall i : 'I_n.+1, 0 <= k (Ordinal (flt i)) by [].
-   move=>/(_ k0').
-   have kA': forall i : 'I_n.+1, (mkseq (fun i0 : nat => s`_(f i0)) n.+1)`_i \in A.
-      by move=>j; rewrite nth_mkseq //; move: (kA (Ordinal (flt j))).
-   move=>/(_ kA' (fun i => mu (Ordinal (flt i)))).
-   have mu'R: \sum_(i0 < n.+1) mu (Ordinal (flt i0)) = 0.
-      rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
-      by rewrite big_map -{4}muR; apply congr_big=>// [[j jlt]] _; congr mu; apply val_inj, fcan.
-   move=>/(_ mu'R).
-   have mu'E: \sum_(i0 < n.+1) mu (Ordinal (flt i0)) *: (mkseq (fun i1 : nat => s`_(f i1)) n.+1)`_i0 = 0.
-      rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
-      rewrite big_map -{6}muE; apply congr_big=>// [[j jlt]] _.
-      rewrite nth_mkseq //; congr (mu _ *: s`_(_)); [ apply val_inj |]; apply fcan.
-   move=>/(_ mu'E (Ordinal (flt im))).
-   have muip': 0 < mu (Ordinal (flt (Ordinal (flt im)))) by refine (eq_ind _ (fun x => 0 < x) muip _ _); congr mu; destruct im; apply val_inj; apply /esym; apply fcan.
-   move=>/(_ muip').
-   have muim': forall j : ordinal_finType n.+1,
-  0 < mu (Ordinal (flt j)) ->
-  k (Ordinal (flt (Ordinal (flt im)))) /
-  mu (Ordinal (flt (Ordinal (flt im)))) <=
-  k (Ordinal (flt j)) / mu (Ordinal (flt j)).
-      move=>j mujp.
-      refine (eq_ind _ (fun i => k i / mu i <= k (Ordinal (flt j)) / mu (Ordinal (flt j))) (muim _ mujp) _ _).
-      destruct im; apply /esym; apply val_inj, fcan.
-   move=>/(_ muim').
-   have im0: Ordinal (flt im) == ord0.
-      by apply /eqP; apply val_inj=>/=; rewrite /f; rewrite eq_refl.
-   move=>/(_ im0) [s' [s'conv [s'size s'A]]].
-   exists s'; split=>//.
-      refine (eq_ind _ (fun x => x \in conv [set` s']) s'conv _ _).
-      rewrite (perm_big _ (perm_map_bij _ fbij)); [| exact nil ].
-      rewrite big_map; apply congr_big=>// [[j jlt]] _.
-      rewrite nth_mkseq //.
-      by congr (k _ *: s`_(_)); [ apply val_inj |]; apply fcan.
-move=>/eqP ime; subst im.
-case: s ns kA muE=> // a s ns kA muE.
-inversion ns; subst n; clear ns.
-have leS: forall n m, (n <= m -> n < m.+1)%N by move=> n m; rewrite ltnS.
-move: (IHn s Logic.eq_refl (fun i => k (lift ord0 i) - k ord0 / mu ord0 * mu (lift ord0 i))); clear IHn.
-have mu0: mu ord0 != 0 by apply /eqP=>mu0; move: muip; rewrite mu0 lt0r eq_refl.
-have k0mu0: k ord0 / mu ord0 * mu ord0 = k ord0 by rewrite -{2}[mu ord0]divr1 mulf_div [_*1]mulrC -mulf_div divr1 mulfV // mulr1.
-have k1': \sum_i (k (lift ord0 i) - k ord0 / mu ord0 * mu (lift ord0 i)) = 1
-   by rewrite -[1]subr0 -{2}(mulr0 (k ord0 / mu ord0)) -k1 -{3}muR mulr_sumr -sumrB big_ord_recl k0mu0 subrr add0r; apply congr_big.
-move=>/(_ k1').
-have kp: forall i : 'I_(size s), 0 <= k (lift ord0 i) - k ord0 / mu ord0 * mu (lift ord0 i).
-   move=>j; rewrite subr_ge0.
-   case mujp: (0 < mu (lift ord0 j)).
-      by rewrite -ler_pdivl_mulr //; apply muim.
-   apply/(le_trans _ (k0 (lift ord0 j)))/mulr_ge0_le0.
-      apply divr_ge0=>//.
-      by move: muip; rewrite lt0r=>/andP [_ ->].
-   rewrite real_leNgt.
-      by rewrite mujp.
-      by apply num_real.
-   by apply num_real.
-move=>/(_ kp).
-have kA': forall i : 'I_(size s), s`_i \in A by move=>j; move: (kA (lift ord0 j)).
-move=>/(_ kA') [s' [s'conv s'ok]].
-exists s'; split=>//.
-apply (eq_ind _ (fun x => x \in conv [set` s']) s'conv).
-by rewrite -[\sum_i k i *: (a :: s)`_i]subr0 -{5}(scaler0 _ (k ord0 / mu ord0)) -{5}muE scaler_sumr -sumrB big_ord_recl scalerA k0mu0 subrr add0r; apply congr_big=>// i _; rewrite scalerA scalerBl.
-Qed.
-
-
-End vect.
-
-Section prod.
-
-Variable R: realType.
-Variable E F: lmodType R.
-
-Local Open Scope fun_scope.
-Local Open Scope ring_scope.
-
-Lemma conv_prod (A: set E) (B: set F): conv (A `*` B) = ((conv A) `*` (conv B))%classic.
-Proof.
-rewrite eqEsubset; split.
-   apply conv_sub_convex.
-      by apply setSM; apply conv_ext.
-   move=> [xa xb] [ya yb] [xaA xbB] [yaA ybB] z [t ht01 <-] /=; split.
-      by apply (conv_convex xaA yaA); exists t.
-   by apply (conv_convex xbB ybB); exists t.
-move=>[x y] [[sx [kx [kx1 /= <- kx0 kxA]]]] [sy [ky [ky1 /= <- ky0 kyA]]].
-exists (allpairs (fun x y=> (x, y)) sx sy).
-rewrite size_allpairs; exists (fun i => let (i, j) := split_prod i in kx i * ky j).
-split.
-- rewrite big_prod_ord -kx1; apply congr_big=>// i _.
-  rewrite -[kx i]mulr1 -ky1 mulr_sumr; apply congr_big=>// j _.
-  by move: (unsplit_prodK (i, j))=>[-> ->].
-- transitivity (\sum_i (let (i0, j) := split_prod i in (kx i0 * ky j) *: sx`_i0, let (i0, j) := split_prod i in (kx i0 * ky j) *: sy`_j)).
-    by apply congr_big=> // i _; rewrite (nth_allpairs _ 0 0); case: split_prod=>o o0.
-  rewrite big_pair; apply pair_equal_spec; split; rewrite big_prod_ord.
-    by apply congr_big=>// i _; rewrite -[kx i *: sx`_i]scale1r -ky1 scaler_suml; apply congr_big=>// j _; move: (unsplit_prodK (i, j))=>[-> ->]; rewrite mulrC scalerA.
-  by rewrite -[\sum_(i < size sy) ky i *: sy`_i]scale1r -kx1 scaler_suml; apply congr_big=>// i _; rewrite scaler_sumr; apply congr_big=>// j _; move: (unsplit_prodK (i, j))=>[-> ->]; rewrite scalerA.
-- move=> i.
-  by case: split_prod=>o o0; apply mulr_ge0.
-- move=> i.
-  by rewrite (nth_allpairs _ 0 0); case: split_prod=>o o0; apply mem_set; split; apply set_mem=>/=.
-Qed.
-
-End prod.
 
 Section face.
 
-Variable R: realType.
-Variable E: lmodType R.
-Variable A: set E.
+Variable E: convType.
 
 Local Open Scope fun_scope.
 Local Open Scope ring_scope.
 
-Definition ext := [set x | forall u v, u \in A -> v \in A -> x \in segment u v -> x = u \/ x = v]%classic.
+Definition ext (A : set E) := [set x | forall u v, u \in A -> v \in A -> x \in segment u v -> x = u \/ x = v]%classic.
 
-Definition face (F: set E) := (F `<=` A)%classic /\ convex F /\ forall x u v, x \in F -> u \in A -> v \in A -> x \in segment u v -> x != u -> x != v -> u \in F /\ v \in F.
+Definition face (A F: set E) := (F `<=` A)%classic /\ is_convex_set F /\ forall x u v, x \in F -> u \in A -> v \in A -> x \in segment u v -> x != u -> x != v -> u \in F /\ v \in F.
 
-Definition face' (F: set E) := (F `<=` A)%classic /\ convex F /\ forall x u v, x \in F -> u \in A -> v \in A -> x \in segment u v -> x != v -> u \in F.
+Definition face' (A F: set E) := (F `<=` A)%classic /\ is_convex_set F /\ forall x u v, x \in F -> u \in A -> v \in A -> x \in segment u v -> x != v -> u \in F.
 
-Lemma face'P (F: set E): face F <-> face' F.
+Lemma face'P (A F: set E): face A F <-> face' A F.
 Proof.
 split; move=>[FA [Fconv Fface]]; split=>//; split=>// x u v xF uA vA xuv.
    move=>xv; case xu: (x == u).
@@ -550,65 +175,103 @@ move=>xu xv; split; [ apply (Fface x u v) | apply (Fface x v u) ]=>//.
 by apply mem_set, segment_sym, set_mem.
 Qed.
 
-(* TODO: is it possible to use psatz ? *)
+End face.
+Section face.
 
-Lemma ext_carac (x: E): convex A -> x \in A -> [<-> x \in ext;
-  forall u v, u \in A -> v \in A -> x = 1/2 *: (u+v) -> u = v;
-  convex (A `\ x)%classic;
-  face [set x]].
+Variable E: lmodType R_ringType.
+
+Local Open Scope fun_scope.
+Local Open Scope ring_scope.
+Local Open Scope convex_scope.
+
+Lemma probinvn1 : probinvn 1 = 2^-1 :> R_numFieldType.
 Proof.
-move=>Aconv xA.
+rewrite /R_numFieldType /GRing.inv /= /Rinvx.
+case:ifP=>// /negbFE.
+by rewrite/Rdefinitions.IZR intr_eq0.
+Qed.
+
+Lemma onem_half: onem 2^-1 = 2^-1.
+Proof.
+have ne20: (2 : R_ringType) != 0 by rewrite intr_eq0.
+apply (mulfI ne20).
+by rewrite mulrBr mulr1 divff// -pmulrn mulr2n -addrA subrr addr0.
+Qed.
+
+Lemma ext_carac (A : {convex_set E}) (x: E): x \in A -> [<-> x \in ext A;
+  forall u v, u \in A -> v \in A -> x = u <| probinvn 1 |> v -> u = v;
+  is_convex_set (A `\ x)%classic;
+  face A [set x]].
+Proof.
+move=>xA.
+have ne20: (2 : R_ringType) != 0 by rewrite intr_eq0.
+have ge20: (0 : R_ringType) <= 2 by apply mulrz_ge0=>//; exact ler01.
 split.
    move=>xext u v uA vA xe.
    move: xext=>/set_mem /(_ u v uA vA).
    have xuv: x \in segment u v.
-      apply mem_set; subst x; exists (1 / 2).
-        by rewrite /= in_itv/= div1r invr_ge0 ler0n invf_le1 ?ltr0n// ler1n.
-      by rewrite /conv' {3}(splitr 1) -addrA subrr addr0 scalerDr.
-   move: uA vA=>_ _ /(_ xuv); move: xuv=>_.
+      by apply mem_set; subst x; exists (probinvn 1).
+   move=>{uA} {vA} /(_ xuv) {xuv}.
    wlog: u v xe / x = u.
       move=> h; case=> xe'.
          by apply h=>//; left.
-      apply /esym; apply h=>//.
-         by rewrite addrC.
-         by left.
+      apply /esym; apply h=>//; last by left.
+      rewrite xe convC; congr (v <| _ |> u).
+      apply val_inj=>/=.
+      rewrite probinvn1 /onem.
+      by apply/eqP; rewrite subr_eq -(div1r 2) -splitr.
       move: xe=> -> + _.
-      move=> /(f_equal (fun x => 2 *: x));
-      rewrite scalerA -{1}[2]divr1 mulf_div mul1r mulr1 divff ?pnatr_eq0// scale1r.
-      by rewrite scalerDl scale1r addrC; move=>/(f_equal (fun x => x-u)); do 2 rewrite -addrA subrr addr0.
+      move=> /(congr1 (fun x => 2 *: x)).
+      rewrite scalerDr probinvn1 onem_half 2!scalerA divff// 2!scale1r.
+      by rewrite -pmulrn mulr2n scalerDl scale1r=>/addrI/esym.
 split.
-   move=>xext u v [uA ux] [vA vx] y yuv.
-   split.
-      by apply (Aconv _ _ uA vA).
-   move: yuv=> [t t01 ye] /= yx; subst y x.
-   have xe': forall (t: R) (u v: E), (1 - t) *: v + (1 - (1 - t)) *: u = t *: u + (1-t) *: v by move=>t' u' v'; rewrite addrC onemK.
-   wlog: u v t xext xA uA ux vA vx t01 / 2*t <= 1.
+   move=>xext.
+   apply/asboolP=>u v t [uA ux] [vA vx].
+   split; first by move:(convex_setP A)=>/asboolP; apply.
+   wlog: u v t xext xA uA ux vA vx / (t : R_ringType) <= 2^-1.
       move=>h.
-      have [tle|tle] := boolP (2 * t <= 1); first exact: (h u v t).
-      apply (h v u (1-t)); rewrite /conv' ?xe'=>//.
-      + exact: in01.
-      + rewrite mulrBr mulr1 ler_subl_addr -ler_subl_addl {2}(_ : 1 = 1%:R)// -natrB//.
-        by move: tle; rewrite -ltNge => /ltW; apply: le_trans.
+      have [tle|tle] := boolP ((t : R_ringType) <= 2^-1); first exact: (h u v t).
+      rewrite convC.
+      apply (h v u (onem t)%:pr)=>//.
+      rewrite -onem_half; apply ler_sub=>//.
+      by move: tle; rewrite -ltNge => /ltW.
    move=>tle.
-   move: xext=>/(_ ((2*t) *: u + (1-2*t) *: v) v).
-   have wA: (2 * t) *: u + (1 - 2 * t) *: v \in A.
-      by apply mem_set, (Aconv _ _ uA vA); exists (2*t)=>//; apply /andP; split; rewrite bnd_simp //; move: t01=>/andP [t0 _]; apply mulr_ge0=>//; rewrite ler0z.
-   move: vA=>/mem_set vA /(_ wA vA).
-   rewrite div1r scalerDr scalerDr scalerA mulrA scalerA [_*(_-_)]mulrDr -{1}mulrN mulrA mulr1 [2^-1+_]addrC [(_+2^-1)*:_]scalerDl -addrA -addrA -scalerDl -{3 4}[2^-1]mulr1 -mulrDr.
-   rewrite mulVf ?pnatr_eq0// mul1r mul1r -scalerDl [_+1]addrC.
-   move=>/(_ Logic.eq_refl) /(f_equal (fun x => x-v)).
-   rewrite [1-_]addrC scalerDl scale1r -addrA -addrA subrr addr0 scaleNr -scalerN-scalerDr.
+   have t01: ssrR.leRb (Rdefinitions.IZR BinNums.Z0) (2*(t : R_ringType)) &&
+  ssrR.leRb (2*(t : R_ringType)) (Rdefinitions.IZR (BinNums.Zpos 1%AC)).
+      apply/andP; split; apply/ssrR.leRP/RleP.
+         apply mulr_ge0=>//.
+         by apply/RleP/prob_ge0.
+      by move:tle=>/(ler_wpmul2l ge20); rewrite divff.
+   move=>/esym xE.
+   move: xext=>/(_ (u <| Prob.mk t01 |> v) v).
+   rewrite -convA' convmm.
+   have ->: p_of_rs (Prob.mk t01) (probinvn 1) = t.
+      apply val_inj.
+      rewrite/= p_of_rsE/=.
+      have tE: (2*(t : R_ringType))/2 = t.
+         by rewrite mulrAC divff// mul1r.
+      rewrite -{2}tE.
+      congr Rdefinitions.RbaseSymbolsImpl.Rmult.
+      rewrite/R_unitRing/GRing.inv/=/Rinvx.
+      case:ifP=>//.
+      by rewrite ne20.
+   have wA: u <| Prob.mk t01 |> v \in A.
+      by apply mem_set; move:(convex_setP A)=>/asboolP; apply.
+   move: vA=>/mem_set vA /(_ wA vA xE) /(congr1 (fun x => x-v)).
+   rewrite subrr /conv/= -addrA -{2}(scale1r v) -scalerBl addrAC subrr add0r scaleNr -scalerBr.
    apply /eqP; rewrite scaler_eq0; apply /negP=>/orP; case.
-      rewrite mulf_eq0 pnatr_eq0/= => t0.
-      by move: t0 vx=>/eqP e0; subst t; apply=>/=; rewrite conv'0.
+      rewrite mulf_eq0 pnatr_eq0/= =>/eqP t0.
+      move:xE.
+      have ->: t = 0%:pr by apply val_inj.
+      by rewrite conv0=>/esym.
    rewrite subr_eq0=>/eqP uv; subst v.
-   by move: ux; apply=>/=; rewrite conv'xx.
+   by move:xE; rewrite convmm=>/esym.
 split.
-   move=> Axconv.
-   split; [ by move=>u /= ->; apply set_mem |]; split; [ by apply convex1 |]=> y u v /set_mem -> /set_mem uA /set_mem vA /set_mem xuv xu xv; exfalso.
+   move=>/asboolP Axconv.
+   split; [ by move=>u /= ->; apply set_mem |]; split; [ by apply is_convex_set1 |]=> y u v /set_mem -> /set_mem uA /set_mem vA /set_mem [p _ xE] xu xv; exfalso.
    have uAx: (A `\ x)%classic u by split=>//= ux; subst u; move: xu; rewrite eq_refl.
    have vAx: (A `\ x)%classic v by split=>//= vx; subst v; move: xv; rewrite eq_refl.
-   have: (A `\ x)%classic x by apply (Axconv _ _ uAx vAx).
+   have: (A `\ x)%classic x by rewrite -{2}xE; apply (Axconv _ _ _ uAx vAx).
    by move=>[_ /= f].
 move=>xface; apply /mem_set=>u v uA vA xuv.
 suff: (x == u) || (x == v) by move=>/orP; case=> /eqP ->; [ left | right ].
@@ -619,17 +282,7 @@ move=>/(_ xx uA vA xuv xu xv) [/set_mem /= ux /set_mem /= vx]; subst u.
 by move: xu; rewrite eq_refl.
 Qed.
 
-End face.
-Section face.
-
-Variable R: realType.
-Variable E: lmodType R.
-Variable A: set E.
-
-Local Open Scope fun_scope.
-Local Open Scope ring_scope.
-
-Lemma face_trans (F: set E) (G: set E): face A F -> face F G -> face A G.
+Lemma face_trans (A : set E) (F : set E) (G : set E) : face A F -> face F G -> face A G.
 Proof.
 move=>[AF [Fconv Fface]] [FG [Gconv Gface]].
 split.
@@ -641,11 +294,18 @@ have [uF vF]: (u \in F /\ v \in F).
 by apply (Gface x).
 Qed.
 
-Definition hyperplan_appui (f: {linear E -> GRing.regular_lmodType R}) (a: R) := (exists x, x \in A /\ f x = a) /\ ((forall x, x \in A -> f x <= a) \/ (forall x, x \in A -> a <= f x)).
+Definition hyperplan_appui (A : set E) (f: {linear E -> GRing.regular_lmodType R_ringType}) (a: R_ringType) := (exists x, x \in A /\ f x = a) /\ ((forall x, x \in A -> f x <= a) \/ (forall x, x \in A -> a <= f x)).
 
-Lemma hyperplan_appui_face (f: {linear E -> GRing.regular_lmodType R}) (a: R): convex A -> hyperplan_appui f a <-> (exists x, x \in A /\ f x = a) /\ face A (A `&` (preimage f [set a])).
+Lemma is_convex_set_preimage [T U : convType] (f : {affine T -> U}) (A : {convex_set U}) : is_convex_set (f @^-1` A)%classic.
 Proof.
-move=>Aconv; split; move=>[hex hface]; split=>//.
+apply/asboolP=>x y p/= Ax Ay.
+by rewrite affine_conv -in_setE; apply/mem_convex_set; rewrite in_setE.
+Qed.
+
+(* TOTHINK : lemmas prove is_convex_set but use {convex_set _}. *)
+Lemma hyperplan_appui_face (A : {convex_set E}) (f: {linear E -> GRing.regular_lmodType R_ringType}) (a: R_ringType): hyperplan_appui A f a <-> (exists x, x \in A /\ f x = a) /\ face A (A `&` (preimage f [set a])).
+Proof.
+split; move=>[hex hface]; split=>//.
    wlog: f a hex hface / (forall x : E, x \in A -> f x <= a).
       move=>h; move: (hface); case=>hf.
          by apply (h f a).
@@ -656,42 +316,49 @@ move=>Aconv; split; move=>[hex hface]; split=>//.
       move=>/(_ hex' (or_introl hf') hf'); congr (face A (A `&` _)).
       by rewrite eqEsubset; split=>x /= /eqP; rewrite -scaleN1r linearZZ scaleN1r; [ rewrite eqr_opp | rewrite -eqr_opp ]=>/eqP.
    move=> hf; apply face'P; split; [ by apply subIsetl |]; split.
-      apply convexI=>//; apply convex_convE; rewrite -preimage_conv_linE; [ congr (f @^-1` _)%classic |].
-         by apply (@convex_convE R (GRing.regular_lmodType R) [set a]%classic), convex1.
-      by move: hex=> [x [xA fx]] b ->; exists x.
-   move=> x u v /set_mem [xA xa] uA vA /set_mem [t t01 tx] xv; apply mem_set; (split; [ by apply set_mem |]); apply /eqP; rewrite -lte_anti; apply /andP; (split; [ by apply hf |]).
-   have t0: t != 0.
-      by apply /eqP=>t0; subst t; move: tx xv; rewrite conv'0 => ->; rewrite eqxx.
-   have tgt: 0 < t.
-      by rewrite lt0r t0=>/=; move: t01=>/andP [t0' _]; rewrite bnd_simp in t0'.
-   move: tx=>/(f_equal (fun x=> t^-1 *: (x-(1-t)*: v))); rewrite -addrA subrr addr0 scalerA mulVf // scale1r=>->; rewrite linearZZ linearD xa -scaleNr linearZZ ler_pdivl_mull // addrC -subr_ge0 -addrA -mulNr -{1}[a]mul1r -mulrDl scaleNr -scalerN -mulrDr; apply mulr_ge0.
-      by rewrite subr_ge0; move: t01=>/andP [_ /idP]; rewrite bnd_simp.
+      exact (is_convex_setI _ (convex_set_of (is_convex_set_preimage _ (convex_set_of (is_convex_set1 (a : GRing.regular_lmodType R_ringType)))))).
+   move=> x u v /set_mem [xA xa] uA vA /set_mem [t _ tx] xv; apply mem_set; (split; [ by apply set_mem |]); apply /eqP; rewrite -lte_anti; apply /andP; (split; [ by apply hf |]).
+   have t0: (t : R_ringType) != 0.
+      by apply /eqP=>/val_inj t0; subst t; move: tx xv; rewrite conv0 => ->; rewrite eqxx.
+   have tgt: 0 < (t : R_ringType) by rewrite lt0r t0=>/=; apply/RleP/prob_ge0.
+   move: tx=>/(f_equal (fun x=> (t : R_ringType)^-1 *: (x-((onem t) : R_ringType)*: v))).
+   rewrite -addrA subrr addr0 scalerA mulVf // scale1r=>->.
+   rewrite linearZZ linearD xa -scaleNr linearZZ ler_pdivl_mull// addrC -subr_ge0 -addrA -mulNr -{1}[a]mul1r -mulrDl scaleNr -scalerN -mulrDr; apply mulr_ge0.
+      by apply/RleP/prob_ge0.
    by rewrite addrC Num.Internals.subr_ge0; apply hf.
 have: forall x y, x \in A -> y \in A -> f x < a -> a < f y -> False.
-move=> u v uA vA fua afv; move: hface=>/face'P [_ [_ /(_ ((f v - a)/(f v - f u) *: u + (a - f u)/(f v - f u) *: v) u v)]].
+   move=> u v uA vA fua afv.
    move: (Order.POrderTheory.lt_trans fua afv); rewrite -subr_gt0=>fufv.
-   have inuv: ((f v - a) / (f v - f u)) *: u + ((a - f u) / (f v - f u)) *: v \in segment u v.
-      apply mem_set; exists ((f v - a) / (f v - f u)).
-         apply /andP; split; rewrite bnd_simp.
-            by apply divr_ge0; [ move: afv; rewrite -subr_gt0 | move: fufv ]; rewrite lt0r=>/andP [_ h].
-         rewrite ler_pdivr_mulr // mul1r; apply ler_sub=>//.
-         by rewrite -subr_ge0; move: fua; rewrite -subr_gt0 lt0r=>/andP [_ h].
-      congr (_ + _ *: v).
+   have t01: ssrR.leRb (Rdefinitions.IZR BinNums.Z0) ((f v - a) / (f v - f u)) &&
+  ssrR.leRb ((f v - a) / (f v - f u)) (Rdefinitions.IZR (BinNums.Zpos 1%AC)).
+      apply/andP; split; apply/ssrR.leRP/RleP.
+         by apply divr_ge0; apply ltW=>//; rewrite subr_gt0.
+         rewrite ler_pdivr_mulr// mul1r -subr_ge0 opprB addrAC addrCA subrr addr0 subr_ge0.
+         by apply ltW.
+   move: hface=>/face'P [_ [_ /(_ (u <| Prob.mk t01 |> v) u v)]].
+   have inuv: u <| Prob.mk t01 |> v \in segment u v.
+      by apply mem_set; exists (Prob.mk t01).
+   have uva: f (u <| Prob.mk t01 |> v) = a.
+      rewrite/= affine_conv/=/conv/=.
       move: fufv; rewrite lt0r=>/andP [fufv _].
-      move: (oner_neq0 R)=>ne10.
-      by rewrite -[1](divff fufv) -mulrBl; congr (_ / _); rewrite opprB addrA addrC addrA addrA [-_+_]addrC subrr add0r addrC.
-   have Aa: ((f v - a) / (f v - f u)) *: u + ((a - f u) / (f v - f u)) *: v \in (A `&` f @^-1` [set a])%classic.
-      apply mem_set; split.
-         by apply (Aconv u v); by apply set_mem. 
-      move: fufv; rewrite lt0r=>/andP [fufv _].
-      by rewrite /= linearD linearZZ linearZZ [_*:_]mulrC [_*:_]mulrC mulrA mulrA -mulrDl addrC mulrBr mulrBr addrA -[_ - _ + _]addrA [-_+_]addrC [f u * _]mulrC subrr addr0 -mulrBl [_*a]mulrC -mulrA mulfV // mulr1.
+      apply (mulfI fufv).
+      rewrite/GRing.regular_lmodType/GRing.scale/=.
+      rewrite mulrDr mulrAC mulrCA mulrAC divff// mulr1.
+      rewrite [onem _ * _]mulrBl mul1r mulrBr mulrAC mulrCA mulrAC divff// mulr1.
+      rewrite -mulrBl opprB addrAC addrCA subrr addr0.
+      rewrite 2!mulrBl mulrC addrAC addrCA subrr addr0.
+      by rewrite -mulrBr mulrC.
+   have Aa: u <| Prob.mk t01 |> v \in (A `&` f @^-1` [set a])%classic.
+      apply mem_set; split=>//.
+      by move:(convex_setP A)=>/asboolP; apply; rewrite -in_setE.
    move=>/(_ Aa uA vA inuv).
-   have nev: ((f v - a) / (f v - f u)) *: u + ((a - f u) / (f v - f u)) *: v != v.
-      apply /eqP=>/(f_equal (fun x => (f v - f u) *: (x - ((a - f u) / (f v - f u)) *: v))).
-      move: fufv; rewrite lt0r=>/andP [fufv _].
-      rewrite -addrA subrr addr0 scalerA mulrA [_*(_-_)]mulrC scalerBr scalerA mulrA [(_-_)*(a-_)]mulrC -mulrA -mulrA mulfV // mulr1 mulr1 -scalerBl opprB addrA -[_-_+_]addrA [-_+_]addrC subrr addr0=>/eqP; rewrite -subr_eq0 -scalerBr scaler_eq0=>/orP; case.
-         by move=>fva; move: afv; rewrite -subr_gt0 lt0r fva.
-      by rewrite subr_eq0; move=>/eqP uv; subst v; move: fufv; rewrite subrr eq_refl.
+   have nev: u <|{| Prob.p := (f v - a) / (f v - f u); Prob.Op1 := t01 |}|> v != v.
+      rewrite -subr_eq0 -{4}(scale1r v) -addrA -scalerBl addrAC subrr add0r scaleNr -scalerBr scaler_eq0 subr_eq0.
+      apply/negP=>/orP; case=>/eqP.
+         move=>/= t0.
+         move:uva; rewrite/conv/= t0 scale0r add0r onem0 scale1r=>fva.
+         by move:afv; rewrite fva lt_irreflexive.
+      by move=>uv; move:fufv; rewrite uv subrr lt_irreflexive.
    by move=>/(_ nev) /set_mem [_ /= fuae]; move: fua; rewrite fuae -subr_gt0 lt0r subrr eq_refl.
 move=>h.
 move: (boolp.EM (exists x: E, x \in A /\ f x < a)); case.
@@ -704,110 +371,119 @@ Qed.
 End face.
 Section cone.
 
-Variable R: realType.
-Variable E: lmodType R.
+Variable E: lmodType R_ringType.
 
 Local Open Scope fun_scope.
 Local Open Scope ring_scope.
+Local Open Scope convex_scope.
 
-Definition cone0 (A: set E) := ([set t *: a | t in [set t: R | 0 < t] & a in A] `<=` A)%classic.
+Definition cone0 (A: set E) := ([set (t : R_ringType) *: a | t in (@setT Rpos) & a in A] `<=` A)%classic.
 Definition cone (x: E) (A: set E) := cone0 [set a-x | a in A]%classic.
 
-Lemma cone0_convex (A: set E): cone0 A -> (convex A <-> ([set a+b | a in A & b in A] `<=` A)%classic).
+Lemma cone0_convex (A: set E): cone0 A -> (is_convex_set A <-> ([set a+b | a in A & b in A] `<=` A)%classic).
 Proof.
+have ne20: (2 : R_ringType) != 0 by rewrite intr_eq0.
+have /RltP/ssrR.ltRP gt20: (0 : R_ringType) < 2 by rewrite ltr0z.
 move=>Acone; split=>Aconv.
    move=>x [u uA] [v vA] <-.
-   have uA2: A (2 *: u) by apply Acone; exists 2; [ rewrite /= ltr0z | exists u ].
-   have vA2: A (2 *: v) by apply Acone; exists 2; [ rewrite /= ltr0z | exists v ].
-   apply (Aconv _ _ uA2 vA2); exists (2^-1).
-      apply /andP; split; rewrite bnd_simp.
-         by rewrite invr_ge0 ler0z le0z_nat.
-      by rewrite invf_le1 ?ler1z ?ltr0z.
-   rewrite /conv'.
-   have->: 1-2^-1 = (2^-1: R) by rewrite {1}(splitr 1) div1r addrK.
-   by rewrite !scalerA mulVf ?pnatr_eq0// !scale1r.
-move=>x y xA yA z [t /andP]; (do 2 rewrite bnd_simp)=>[[t0 t1]] <-.
-move: t0; rewrite le0r=>/orP; case.
-   by move=>/eqP ->; rewrite conv'0.
-move=>t0; move: t1; rewrite -subr_ge0 le0r=>/orP; case.
-   by rewrite subr_eq0 => /eqP <-; rewrite conv'1.
-move=> t1; apply Aconv; exists (t*:x); [| exists ((1-t)*:y) ]=>//; apply Acone.
-   by exists t=>//; exists x.
-by exists (1-t)=>//; exists y.
+   have uA2: A (2 *: u) by apply Acone; exists (Rpos.mk gt20)=>//; exists u.
+   have vA2: A (2 *: v) by apply Acone; exists (Rpos.mk gt20)=>//; exists v.
+   move:Aconv=>/asboolP/(_ _ _ (probinvn 1) uA2 vA2); congr A.
+   by rewrite/conv/= probinvn1 onem_half 2!scalerA mulrC divff// 2!scale1r.
+apply/asboolP.
+move=>x y t xA yA.
+move:(prob_ge0 t)=>/RleP; rewrite le0r=>/orP; case.
+   by rewrite/conv/= =>/eqP ->; rewrite scale0r add0r onem0 scale1r.
+move=>/RltP/ssrR.ltRP t0; move: (prob_le1 t)=>/RleP; rewrite -subr_ge0 le0r=>/orP; case.
+   by rewrite subr_eq0 /conv/= =>/eqP <-; rewrite onem1 scale0r addr0 scale1r.
+move=>/RltP/ssrR.ltRP t1; apply Aconv; exists ((t : R_ringType) *: x); [| exists ((onem t) *: y) ]=>//; apply Acone.
+   by exists (Rpos.mk t0)=>//; exists x.
+by exists (Rpos.mk t1)=>//; exists y.
 Qed.
 
 (* Note: cone0_of A is NOT pointed due to lemma cone0_of_convE. *)
 (* TODO: maybe change the 0 <= k i to 0 < k i in the definition of conv. *)
 
-Definition cone0_of (A: set E): set E := fun a: E => exists x (s: seq E) (k: 'I_(size (x::s)) -> R),
-  [/\ \sum_i (k i) *: (x::s)`_i = a, (forall i, 0 < k i) & (forall i: 'I_(size (x::s)), (x::s)`_i \in A)].
+Definition cone0_of (A: set E): set E := [set a | exists n (s : 'I_n.+1 -> E) (k: 'I_n.+1 -> Rpos),
+  \sum_i (k i : R_ringType) *: (s i) = a /\ (range s `<=` A)%classic].
 
 Lemma cone0_of_cone0 (A: set E): cone0 (cone0_of A).
 Proof.
-move=>x [t /= t0] [a [y [s [k [<- k0 kA]]]]] <-.
-rewrite scaler_sumr; exists y, s; exists (fun i => t * k i); split => //.
-- by apply congr_big=>// i _; apply /esym; apply scalerA.
-- by move=> i; apply mulr_gt0.
+move=>x [t /= _] [a [n [s [k [<- sA]]]]] <-.
+rewrite scaler_sumr; exists n, s, (fun i => mulRpos t (k i)); split => //.
+by apply congr_big=>// i _; apply /esym; apply scalerA.
 Qed.
 
-Lemma cone0_of_convE (A: set E): cone0_of A = [set t *: a | t in [set t | 0 < t] & a in (conv A)]%classic.
+Lemma cone0_of_hullE (A: set E): cone0_of A = [set (t : R_ringType) *: a | t in (@setT Rpos) & a in (hull A)]%classic.
 Proof.
 rewrite eqEsubset; split=>x.
-   move=>[y [s [k [<- k0 kA]]]]; set t := \sum_i k i.
-   have k0': forall i : ordinal_finType (size (y :: s)), true -> 0 <= k i by move=>i _; apply ltW.
+   move=>[n [s [k [<- kA]]]]; set t := \sum_i (k i : R_ringType).
+   have k0': forall i : ordinal_finType n.+1, true -> 0 <= (k i : R_ringType) by move=>i _; apply/ltW/RltP/Rpos_gt0.
    have: 0 <= t by apply sumr_ge0.
    rewrite le0r=>/orP; case.
-      by move=>/eqP /psumr_eq0P; move=> /(_ k0') /(_ ord0 Logic.eq_refl) k00; exfalso; move: (k0 ord0); rewrite lt0r k00 eq_refl.
-   move=>t0; exists t=>//; exists (t^-1 *: \sum_i k i *: (y :: s)`_i).
-      exists (y::s), (fun i => t^-1 * k i); split => //.
-      - by rewrite -mulr_sumr mulVf //; move: t0; rewrite lt0r=>/andP[t0 _].
-      - by rewrite scaler_sumr; apply congr_big=>// i _; apply /esym; apply scalerA.
-      - move=> i; apply mulr_ge0.
-         2: by apply (k0' i).
-        by rewrite invr_ge0; apply ltW.
+      move=>/eqP /psumr_eq0P; move=> /(_ k0') /(_ ord0 Logic.eq_refl) k00; exfalso.
+      by move:(Rpos_gt0 (k ord0))=>/RltP; rewrite k00 lt_irreflexive.
+   move=>t0.
+   have tk0: forall i, Rdefinitions.Rle (Rdefinitions.IZR BinNums.Z0) ([ffun i => t^-1 * k i] i).
+      by move=>i; rewrite ffunE; apply/RleP/mulr_ge0; [ apply ltW; rewrite invr_gt0 | apply k0' ].
+   have tk1 : \sum_(i < n.+1) [ffun i => t^-1 * k i] i = 1.
+      transitivity (\sum_(i < n.+1) t^-1 * k i).
+         by apply congr_big=>// i _; rewrite ffunE.
+      rewrite -mulr_sumr mulrC divff//.
+      by move:t0; rewrite lt0r=>/andP[].
+   move:(t0)=>/RltP/ssrR.ltRP t0'; exists (Rpos.mk t0')=>//; exists (t^-1 *: \sum_i (k i : R_ringType) *: s i).
+      exists n.+1, s, (@FDist.make _ (finfun (fun i=> t^-1 * k i)) tk0 tk1); split=> //.
+      rewrite scaler_sumr avgnrE.
+      apply congr_big=>// i _.
+      by rewrite scalerA ffunE.
    by rewrite scalerA divff ?gt_eqF// scale1r.
-move=>[t /= t0] [a [s [k [k1 <- k0 kA]]]] <-.
-rewrite scaler_sumr (@mathcomp_extra.bigID_idem _ _ _ _ _ _ _ _ (fun i=> 0 < k i)); [| apply addrA | apply addrC | apply addr0 ].
-have ->: \sum_(i < size s | true && ~~ (0 < k i)) t *: (k i *: s`_i) = \sum_(i < size s | true && ~~ (0 < k i)) 0 *: 0.
-   apply congr_big=>// i /andP [_ ki0]; move: (k0 i); rewrite le_eqVlt=>/orP; case.
-      by move=>/eqP <-; rewrite scale0r scale0r scaler0.
-   by move=> ki0'; move:ki0; rewrite ki0'.
+move=>[t /= _] [a [n [s [d [sA ->]]]]] <-.
+rewrite avgnrE scaler_sumr (@mathcomp_extra.bigID_idem _ _ _ _ _ _ _ _ (fun i=> 0 < d i)); [| apply addrA | apply addrC | apply addr0 ].
+have ->: \sum_(i | true && ~~ (0 < d i)) (t : R_ringType) *: (d i *: s i) = \sum_(i | true && ~~ (0 < d i)) 0 *: 0.
+   apply congr_big=>// i /andP [_]; rewrite lt0r negb_and negbK.
+   move:(FDist.ge0 d i)=>/RleP->; rewrite orbF=>/eqP->.
+   by rewrite 2!scale0r GRing.scaler0.
 rewrite -[\sum_(_ < _ | _) 0 *: 0]scaler_sumr scale0r addr0 -big_filter /=.
-remember [seq i <- index_enum (ordinal_finType (size s)) | 0 < k i] as I; move: HeqI=>/esym HeqI.
+remember [seq i <- index_enum (ordinal_finType n) | 0 < d i] as I; move: HeqI=>/esym HeqI.
 case: I HeqI=> [| i I] HeqI.
-exfalso; move: k1 (oner_neq0 R); rewrite (@mathcomp_extra.bigID_idem _ _ _ _ _ _ _ _ (fun i=> 0 < k i)); [| apply addrA | apply addrC | apply addr0 ]. rewrite -big_filter HeqI big_nil add0r=><- /eqP; apply. 
-   transitivity (\sum_(i < size s | true && ~~ (0 < k i)) (0*0:R)).
+   exfalso; move: (FDist.f1 d) (oner_neq0 R_ringType); rewrite (@mathcomp_extra.bigID_idem _ _ _ _ _ _ _ _ (fun i=> 0 < d i)); [| apply addrA | apply addrC | apply addr0 ].
+   rewrite -big_filter HeqI big_nil/=.
+   have ->: forall x, Rdefinitions.RbaseSymbolsImpl.Rplus Rdefinitions.RbaseSymbolsImpl.R0 x = 0+x by [].
+   have ->: Rdefinitions.IZR (BinNums.Zpos 1%AC) = 1 by [].
+   rewrite add0r=><- /eqP; apply. 
+   transitivity (\sum_(i < n | true && ~~ (0 < d i)) (0*0:R_ringType)).
       2: by rewrite -mulr_sumr mul0r.
-   by apply congr_big=>// i /= kile; move: (k0 i); rewrite le0r mul0r=>/orP; case=> [ /eqP // | kigt ]; move: kigt kile=>->.
-have: subseq (i::I) (index_enum (ordinal_finType (size s))) by rewrite -HeqI; apply filter_subseq.
-case: s k k1 k0 kA i I HeqI=> [| b s] k k1 k0 kA i I HeqI.
+   by apply congr_big=>// i /= dile; move: (FDist.ge0 d i)=>/RleP; rewrite le0r mul0r=>/orP; case=> [ /eqP // | ]; move: dile=>/[swap]->.
+have: subseq (i::I) (index_enum (ordinal_finType n)) by rewrite -HeqI; apply filter_subseq.
+case: n s d sA i I HeqI=> [| n] s d sA i I HeqI.
    by inversion i.
 move=> /subseq_incl; move=> /(_ ord0); rewrite size_index_enum card_ord; move=> [f [fn flt]].
-rewrite /cone0_of.
-exists (b::s)`_i, [seq (b::s)`_(nth i (i::I) (lift ord0 j)) | j <- index_enum (ordinal_finType (size I))].
-rewrite /= size_map size_index_enum card_ord; exists (fun j => t * k (nth i (i::I) j)).
+rewrite /cone0_of/=.
+exists (size I), (s \o (nth ord0 (i :: I))).
+simple refine (ex_intro _ _ _).
+   move=>j; apply (mulRpos t).
+   simple refine (Rpos.mk _).
+      exact (d (nth ord0 (i :: I) j)).
+   rewrite -HeqI.
+   apply/ssrR.ltRP/RltP/(@nth_filter _ (fun i=> 0 < d i)).
+   by rewrite HeqI.
 split.
-- rewrite -{2}(map_nth_ord i (i :: I)) big_map.
-  apply congr_big=>// j _; rewrite scalerA; congr GRing.scale.
-  case: j; case=> //= j jlt.
-  move: jlt; rewrite ltnS=>jlt.
-  rewrite (nth_map (Ordinal jlt)); [ congr (_`_(nth i I _)) |].
-     2: by rewrite size_index_enum card_ord.
-  rewrite /index_enum; case: index_enum_key=>/=; rewrite -enumT /=.
-  have je: j = Ordinal jlt by [].
-  by rewrite {2 3}je; rewrite nth_ord_enum.
-- move=> j; apply mulr_gt0=>//; rewrite -HeqI.
-  by apply (@nth_filter _ (fun i => 0 < k i)); rewrite HeqI.
-- case; case=>//= j jlt.
-  move: jlt; rewrite ltnS=>jlt.
-  by rewrite (nth_map (Ordinal jlt)) // size_index_enum card_ord.
+   rewrite [in RHS]HeqI.
+   rewrite -[in RHS](mask_true (s:=i :: I) (leqnn (size I).+1)) big_mask.
+   apply congr_big=>// j.
+      by rewrite nth_nseq; case:j=>/= j ->.
+   move=>_ /=.
+   by rewrite scalerA (tnth_nth ord0)/=.
+move=>+/= [j] _ <- =>_.
+by apply sA; eexists.
 Qed.
       
-Lemma cone0_of_sub_cone0_convex (A B: set E): (A `<=` B -> cone0 B -> convex B -> cone0_of A `<=` B)%classic.
+Lemma cone0_of_sub_cone0_convex (A: set E) (B: {convex_set E}) :
+  (A `<=` B -> cone0 B -> cone0_of A `<=` B)%classic.
 Proof.
-rewrite cone0_of_convE=>AB Bcone Bconv x [t t0 [a aA <-]].
+rewrite cone0_of_hullE=>AB Bcone x [t t0 [a aA <-]].
 apply Bcone; exists t=>//; exists a=>//.
-by apply (conv_sub_convex AB).
+by apply (hull_sub_convex AB).
 Qed.
 
 End cone.
@@ -815,133 +491,89 @@ End cone.
 
 Section Fun.
 
-Variable R: realType.
-Variable E: lmodType R.
-Variable f: E -> \bar R.
+Variable E: convType.
+Variable f: E -> \bar R_ringType.
 
 Local Open Scope fun_scope.
 Local Open Scope ring_scope.
 Local Open Scope ereal_scope.
+Local Open Scope convex_scope.
 
-Definition fconvex := forall (x y: E) (t: R), t \in (`[0, 1]%R: interval R) ->
-  f (conv' x y t) <= EFin t * f x + EFin (1-t)%R * f y.
+Definition fconvex := forall (x y: E) (t: prob),
+  f (x <|t|> y) <= EFin (t : R_ringType) * f x + EFin (onem t)%R * f y.
 
-Definition fconvex_strict := forall (x y: E) (t: R), x <> y -> t \in (`]0, 1[%R: interval R) ->
-  f (conv' x y t) < EFin t * f x + EFin (1-t)%R * f y.
+Definition fconvex_strict := forall (x y: E) (t: oprob), x <> y ->
+  f (x <|t|> y) < EFin (t : R_ringType) * f x + EFin (onem t)%R * f y.
 
-Lemma fconvex_max_ext (C: set E) (x: E): fconvex_strict -> convex C -> x \in C -> f x < +oo -> (forall y, y \in C -> f(y) <= f(x)) -> x \in ext C.
+Lemma muleDl_ge0 (R : realDomainType) (x y z : \bar R) :
+  0 <= y -> 0 <= z -> (y + z) * x = y * x + z * x.
 Proof.
-move=> fconv Cconv xC fxoo xmax.
-move: (ext_carac Cconv xC)=>/all_iffLR /(_ 1%N 0%N) /=; apply=> u v uC vC xmid.
-apply /eqP/negP=> /negP /eqP uv.
-move: (fconv u v (2^-1)%R uv).
-have symhalf: ((1:R)-2^-1 = 2^-1)%R by rewrite {1}(splitr 1) div1r addrK.
-have lt02: ((0:R) < 2)%R by rewrite ltr0n.
-have inhalf: (2^-1 \in `]0:R, 1[)%R.
-   apply /andP; split; rewrite bnd_simp.
-      by rewrite invr_gt0.
-   rewrite invf_lt1 // -{1}[1%R]addr0; apply ler_lt_add=>//; exact ltr01.
-move=>/(_ inhalf); rewrite /conv' symhalf -scalerDr.
-move: xmid; rewrite div1r=><-.
-apply /negP; rewrite -leNgt.
-move: xmax (xmax u uC) fxoo=>/(_ v vC).
-generalize (f x) (f u) (f v)=> a b c ca ba aoo.
-case: b ba=> [ b | |] ba.
-   2: by move: ba; rewrite [+oo <= a]leNgt aoo.
-   2:{ rewrite {1}/mule /mule_subdef.
-   by rewrite eqe invr_eq0 pnatr_eq0/= lte_fin invr_gt0 ltr0n.
-   }
-case: c ca=> [ c | |] ca.
-   2: by move: ca; rewrite [+oo <= a]leNgt aoo.
-   2:{ rewrite {2}/mule /mule_subdef.
-   by rewrite eqe invr_eq0 pnatr_eq0/= lte_fin invr_gt0 ltr0n.
-   }
-case: a aoo ba ca=> // a aoo ba ca.
-move: ca ba; (do 3 rewrite lee_fin)=>ca ba.
-by rewrite -mulrDr mulrC ler_pdivr_mulr// mulr_natr mulr2n ler_add.
+case: y=>// [y | _].
+   rewrite lee_fin le0r -lte_fin=>/orP; case=>[/eqP-> _ | y0].
+      by rewrite mul0e 2!add0e.
+   case yne0: (y%:E == 0).
+      by move:yne0 y0=>/eqP->; rewrite lt_irreflexive.
+all: case: z=>// [z | _].
+   1, 3: rewrite lee_fin le0r -lte_fin=>/orP; case=>[/eqP-> | z0].
+      1, 3: by rewrite mul0e 2!adde0.
+   1, 2: case zne0: (z%:E == 0); first by move:zne0 z0=>/eqP->;
+         rewrite lt_irreflexive.
+      have: 0 < y%:E + z%:E by apply adde_gt0.
+      case yzne0: (y%:E + z%:E == 0); move:yzne0.
+         by move=>/eqP->; rewrite lt_irreflexive.
+all: case: x=>[x | |]; rewrite/adde/adde_subdef/mule/mule_subdef/=
+    ?lt0y// ?yne0 ?y0// ?zne0 ?z0//.
+- by rewrite mulrDl.
+- by move=>-> ->. 
+- by move=>-> ->.
+all: case: ifP=>[/eqP/= x0 | _]; last by case: ifP.
+3: by rewrite addr0.
+all: by rewrite (EFin_inj x0) mulr0 addr0.
+Qed.
+
+Lemma lee_pemul (R : realDomainType) (t : R) (x y : \bar R) :
+  (0 < t)%R -> (t%:E * x <= t%:E * y) = (x <= y).
+Proof.
+rewrite -lte_fin=>t0.
+case tne0: (t%:E == 0); first by move:tne0 t0=>/eqP->; rewrite lt_irreflexive.
+case:x=>[x | |]; case:y=>[y | |];
+    rewrite/mule/mule_def/= ?tne0 ?t0// ?leey// ?leNye//.
+move:t0; rewrite 2!lee_fin lte_fin=>t0.
+by rewrite -subr_ge0 -mulrBr pmulr_rge0// subr_ge0.
+Qed.
+
+Lemma fconvex_max_ext (C: {convex_set E}) (x: E):
+  fconvex_strict ->
+  x \in C ->
+  f x < +oo ->
+  (forall y, y \in C -> f y <= f x) ->
+  x \in ext C.
+Proof.
+move=> fconv xC fxoo xmax.
+rewrite in_setE/ext/= =>u v /xmax uC /xmax vC /set_mem [t] _ xE; subst x.
+move: (prob_ge0 t)=>/RleP; rewrite le0r=>/orP; case.
+   by move=>/eqP/val_inj ->; right; rewrite conv0.
+move=>t0.
+move: (prob_le1 t)=>/RleP; rewrite -subr_ge0 le0r=>/orP; case.
+   have->: Rdefinitions.IZR (BinNums.Zpos 1%AC) = Prob.p (1%R)%:pr by [].
+   by rewrite subr_eq0=>/eqP/val_inj <-; left; rewrite conv1.
+rewrite subr_gt0=>t1.
+have t01: ssrR.ltRb (Rdefinitions.IZR BinNums.Z0) t &&
+       ssrR.ltRb t (Rdefinitions.IZR (BinNums.Zpos 1%AC)).
+   by apply/andP; split; apply/ssrR.ltRP/RltP.
+case /boolP: (u == v); first by move=>/eqP->; rewrite convmm; left.
+move=>/eqP uv.
+move:(fconv u v (OProb.mk t01) uv)=>/=.
+have fle: (Prob.p t)%:E * f u + (onem (Prob.p t))%:E * f v <= f (u <|t|> v).
+   have ->: f (u <|t|> v) = (Prob.p t)%:E * f (u <|t|> v) + (onem (Prob.p t))%:E * f (u <|t|> v).
+      rewrite -muleDl_ge0 ?lee_fin /onem ?RminusE -?EFinD.
+      - by rewrite addrCA subrr addr0 mul1e.
+      - by apply ltW.
+      - by rewrite subr_ge0; apply/RleP/prob_le1.
+   apply (@lee_add R_realDomainType); rewrite (@lee_pemul R_realDomainType)=>//.
+   by rewrite subr_gt0.
+by move=>/(le_lt_trans fle); rewrite lt_irreflexive.
 Qed.
 
 
 End Fun.
-
-
-
-
-End Convex.
-
-(* TODO: move to another file *)
-Require Import Coq.Program.Wf.
-
-Section Bezier.
-
-Variable R: realType.
-Variable E: lmodType R.
-
-Local Open Scope fun_scope.
-Local Open Scope ring_scope.
-
-(* Note: in convex.v, this definition generates only one obligation. Why do I have three here ? *)
-Program Fixpoint bezier (x: E) (s: seq E) (t: R) {measure (size s)}: E :=
-  match s with
-  | nil => x
-  | y :: s => (1-t) *: (bezier x (belast y s) t) + t *: (bezier y s t)
-  end.
-Next Obligation.
-Proof. by move=> _ s0 _ _ y s <-; rewrite size_belast. Defined.
-Next Obligation.
-Proof. by move=> _ s0 _ _ y s <-. Defined.
-Next Obligation.
-Proof. by apply measure_wf, Wf_nat.lt_wf. Qed.
-
-(* Note: in convex.conv, bezier _ [::] _ reduces automatically. Why is it not the case now ? *)
-Lemma bezier_nil x t: bezier x [::] t = x.
-Proof.
-rewrite /bezier /bezier_func.
-by rewrite WfExtensionality.fix_sub_eq_ext.
-Qed.
-
-Lemma bezier_cons x y s t: bezier x (y :: s) t = (1-t) *: (bezier x (belast y s) t) + t *: (bezier y s t).
-Proof.
-rewrite /bezier /bezier_func.
-by rewrite WfExtensionality.fix_sub_eq_ext.
-Qed.
-
-Lemma bezier0 x s: bezier x s 0 = x.
-Proof.
-remember (size s) as n; move: Heqn=>/esym Heqn.
-elim: n s Heqn=>[| n IHn].
-   move=> s /size0nil ->; apply bezier_nil.
-case=>// a s sn.
-rewrite bezier_cons subr0 scale1r scale0r addr0.
-by apply IHn; rewrite size_belast; inversion sn.
-Qed.
-
-Lemma bezier1 x s: bezier x s 1 = last x s.
-Proof.
-remember (size s) as n; move: Heqn=>/esym Heqn.
-elim: n x s Heqn=>[| n IHn] x.
-   by move=> s /size0nil ->; apply bezier_nil.
-case=> // a s sn.
-rewrite bezier_cons subrr scale1r scale0r add0r /=.
-by apply IHn; inversion sn.
-Qed.
-
-Lemma bezier_sub_conv x s: subset (bezier x s @` `[0, 1]) (Convex.conv (fun y => y \in (x :: s))).
-Proof.
-move=> y [t t01 <-].
-remember (size s) as n; move: Heqn=>/esym Heqn.
-elim: n x s Heqn=>[| n IHn] x.
-   move=> s /size0nil ->; rewrite bezier_nil.
-   apply Convex.conv_ext.
-   by rewrite inE; apply /eqP.
-case=> // a s sn; rewrite bezier_cons.
-inversion sn.
-have /Convex.conv_mono lsub: subset (fun y : E => y \in x :: belast a s) (fun y : E => y \in x :: a :: s) by move=> z; (do 2 rewrite in_cons)=>/orP; case=> [ -> // | /mem_belast -> ]; rewrite orbT.
-have /(IHn x) /lsub l: size (belast a s) = n by rewrite size_belast.
-have /Convex.conv_mono rsub: subset (fun y : E => y \in a :: s) (fun y : E => y \in x :: a :: s) by move=> z; (do 3 rewrite in_cons)=>/orP; case=>[ -> // | -> ]; rewrite orbT // orbT.
-move: H0=>/(IHn a) /rsub r.
-move: (@Convex.conv_convex _ _ (fun y : E => y \in x :: a :: s) (bezier x (belast a s) t) (bezier a s t) l r); apply.
-by exists (1 - t); [exact: in01 |rewrite /conv' onemK].
-Qed.
-
-End Bezier.

--- a/theories/convex.v
+++ b/theories/convex.v
@@ -79,7 +79,7 @@ rewrite Convn_pair/comp/=; congr pair; apply S1_inj; rewrite !S1_Convn big_prod_
       by refine (inj_eq _ k (i, j)); exact (can_inj (@unsplit_prodK n m)). 
    rewrite (big_pred1 (i, j))// fdist_prodE/= ssrR.mulRC; congr (scalept _ (S1 (g _))).
    by move:(unsplit_prodK (i, j))=>/(congr1 fst)/esym.
-rewrite bigC/=.
+rewrite (exchange_big_dep xpredT)//=.
 apply eq_big=>// j _.
 rewrite -(scale1pt (scalept _ _)) scaleptA//.
 rewrite -(FDist.f1 d).
@@ -505,43 +505,6 @@ Definition fconvex := forall (x y: E) (t: prob),
 Definition fconvex_strict := forall (x y: E) (t: oprob), x <> y ->
   f (x <|t|> y) < EFin (t : R_ringType) * f x + EFin (onem t)%R * f y.
 
-Lemma muleDl_ge0 (R : realDomainType) (x y z : \bar R) :
-  0 <= y -> 0 <= z -> (y + z) * x = y * x + z * x.
-Proof.
-case: y=>// [y | _].
-   rewrite lee_fin le0r -lte_fin=>/orP; case=>[/eqP-> _ | y0].
-      by rewrite mul0e 2!add0e.
-   case yne0: (y%:E == 0).
-      by move:yne0 y0=>/eqP->; rewrite lt_irreflexive.
-all: case: z=>// [z | _].
-   1, 3: rewrite lee_fin le0r -lte_fin=>/orP; case=>[/eqP-> | z0].
-      1, 3: by rewrite mul0e 2!adde0.
-   1, 2: case zne0: (z%:E == 0); first by move:zne0 z0=>/eqP->;
-         rewrite lt_irreflexive.
-      have: 0 < y%:E + z%:E by apply adde_gt0.
-      case yzne0: (y%:E + z%:E == 0); move:yzne0.
-         by move=>/eqP->; rewrite lt_irreflexive.
-all: case: x=>[x | |]; rewrite/adde/adde_subdef/mule/mule_subdef/=
-    ?lt0y// ?yne0 ?y0// ?zne0 ?z0//.
-- by rewrite mulrDl.
-- by move=>-> ->. 
-- by move=>-> ->.
-all: case: ifP=>[/eqP/= x0 | _]; last by case: ifP.
-3: by rewrite addr0.
-all: by rewrite (EFin_inj x0) mulr0 addr0.
-Qed.
-
-Lemma lee_pemul (R : realDomainType) (t : R) (x y : \bar R) :
-  (0 < t)%R -> (t%:E * x <= t%:E * y) = (x <= y).
-Proof.
-rewrite -lte_fin=>t0.
-case tne0: (t%:E == 0); first by move:tne0 t0=>/eqP->; rewrite lt_irreflexive.
-case:x=>[x | |]; case:y=>[y | |];
-    rewrite/mule/mule_def/= ?tne0 ?t0// ?leey// ?leNye//.
-move:t0; rewrite 2!lee_fin lte_fin=>t0.
-by rewrite -subr_ge0 -mulrBr pmulr_rge0// subr_ge0.
-Qed.
-
 Lemma fconvex_max_ext (C: {convex_set E}) (x: E):
   fconvex_strict ->
   x \in C ->
@@ -566,11 +529,11 @@ move=>/eqP uv.
 move:(fconv u v (OProb.mk t01) uv)=>/=.
 have fle: (Prob.p t)%:E * f u + (onem (Prob.p t))%:E * f v <= f (u <|t|> v).
    have ->: f (u <|t|> v) = (Prob.p t)%:E * f (u <|t|> v) + (onem (Prob.p t))%:E * f (u <|t|> v).
-      rewrite -muleDl_ge0 ?lee_fin /onem ?RminusE -?EFinD.
+      rewrite -ge0_muleDl ?lee_fin /onem ?RminusE -?EFinD.
       - by rewrite addrCA subrr addr0 mul1e.
       - by apply ltW.
       - by rewrite subr_ge0; apply/RleP/prob_le1.
-   apply (@lee_add R_realDomainType); rewrite (@lee_pemul R_realDomainType)=>//.
+   apply (@lee_add R_realDomainType); rewrite (@lee_pmul2l R_realDomainType)//= lte_fin.
    by rewrite subr_gt0.
 by move=>/(le_lt_trans fle); rewrite lt_irreflexive.
 Qed.

--- a/theories/intersection.v
+++ b/theories/intersection.v
@@ -239,7 +239,7 @@ have: [exists i : 'I_(size l), det l`_i l`_(Zp_succ i) (conv (sup I) b a) <= 0].
          rewrite ltxI; apply/andP; split; last by apply ltNye.
          by apply ereal_meets_gt=>// i _; apply ltNye.
       suff : (t `&` 1 < +oo)%E by rewrite tinf lt_irreflexive.
-      by rewrite ltIx ltry orbT.
+      by rewrite ltIx [(1 < +oo)%E]ltey orbT.
    move:(It); rewrite -tfin lte_fin ltNge=>/negP; apply.
    have t01: in01 (fine (t `&` 1%E)).
       apply/andP; split; rewrite -lee_fin tfin; last by rewrite lteIx le_refl orbT.

--- a/theories/intersection.v
+++ b/theories/intersection.v
@@ -239,7 +239,7 @@ have: [exists i : 'I_(size l), det l`_i l`_(Zp_succ i) (conv (sup I) b a) <= 0].
          rewrite ltxI; apply/andP; split; last by apply ltNye.
          by apply ereal_meets_gt=>// i _; apply ltNye.
       suff : (t `&` 1 < +oo)%E by rewrite tinf lt_irreflexive.
-      by rewrite ltIx ltey orbT.
+      by rewrite ltIx ltry orbT.
    move:(It); rewrite -tfin lte_fin ltNge=>/negP; apply.
    have t01: in01 (fine (t `&` 1%E)).
       apply/andP; split; rewrite -lee_fin tfin; last by rewrite lteIx le_refl orbT.

--- a/theories/preliminaries.v
+++ b/theories/preliminaries.v
@@ -223,16 +223,7 @@ Qed.
 
 Lemma bigC [R : Type] (idr : R) (opr : Monoid.com_law idr) [I J : Type] (r : seq I) (s : seq J) (P : I -> pred J) (F : I -> J -> R) : \big[opr/idr]_(x <- r) \big[opr/idr]_(y <- s | P x y) F x y = \big[opr/idr]_(y <- s) \big[opr/idr]_(x <- r | P x y) F x y.
 Proof.
-elim:r s=>[|x r IHr] s.
-   rewrite big_nil.
-   elim:s=>[|y s IHs]; first by rewrite big_nil.
-   by rewrite big_cons big_nil -IHs Monoid.mul1m.
-rewrite big_cons.
-elim:s=>[|y s IHs]; first by rewrite IHr 3!big_nil Monoid.mul1m.
-rewrite !big_cons.
-case:ifP=>_; rewrite IHr -IHs big_cons -IHr.
-   by rewrite Monoid.mulmACA.
-by rewrite Monoid.mulmCA.
+exact: exchange_big_dep.
 Qed.
 
 Lemma Convn_pair [T U : convType] [n : nat] (g : 'I_n -> T * U) (d : fdist.fdist_of (Phant 'I_n)): Convn d g = (Convn d (fst \o g), Convn d (snd \o g)).
@@ -244,56 +235,5 @@ case:(Bool.bool_dec _ _).
    by move=>_; rewrite -surjective_pairing.
 move=>d0.
 by move:(IHn (fun i => g (fdist.fdist_del_idx ord0 i)) (fdist.fdist_del (Bool.eq_true_not_negb _ d0))); rewrite/Convn=>->.
-Qed.
-
-From mathcomp Require Import ereal.
-Local Open Scope ereal_scope.
-
-Ltac case_ereal x :=
-  let H0 := fresh "x_eq_0" in
-  let He0 := fresh "Heqx_eq_0" in
-  let Hgt := fresh "x_gt_0" in
-  let Hegt := fresh "Heqx_gt_0" in
-  let Heqlt := fresh "Heqx_lt_0" in
-  case: x=> [ x | |];
-      [ remember (x%:E == 0) as H0; case: H0 He0=>/esym He0;
-      [| remember (0 < x%:E) as Hgt; case: Hgt Hegt=>/esym Hegt;
-          [| (have /Order.TotalTheory.lt_total: (x%:E != 0) by apply /negP; rewrite He0); rewrite Hegt orbF=>Heqlt ]] | |].
-
-(* Takes ~7s to compile.
-Lemma muleA (R: realDomainType) (a b c: \bar R): a * (b * c) = a * b * c.
-Proof.
-rewrite /mule /mule_subdef.
-case_ereal a; case_ereal b; case_ereal c; (try by (congr (_%:E); apply mulrA)); rewrite ?(mule_eq0 a%:E b%:E) ?Heqx_eq_0 ?Heqx_eq_1 ?Heqx_eq2 //= ?mulr0 // ?mul0r // ?eq_refl ?lt0y // ?(mule_eq0 a%:E b%:E) ?(mule_eq0 b%:E c%:E) ?Heqx_eq_0 ?Heqx_eq_1 ?orbT ?orbF // ?(mule_gt0 Heqx_gt_0 Heqx_gt_1) //.
-   1, 2: by rewrite mulrC (pmule_lgt0 b%:E Heqx_gt_0) Heqx_gt_1.
-   1, 2: by rewrite (pmule_lgt0 a%:E Heqx_gt_1) Heqx_gt_0.
-   1, 2: by rewrite (mule_lt0_lt0 Heqx_lt_0 Heqx_lt_1).
-   1, 4: by rewrite mulrC (pmule_lgt0 c%:E Heqx_gt_0) Heqx_gt_1.
-   1, 3: by rewrite (pmule_lgt0 b%:E Heqx_gt_1) Heqx_gt_0.
-   1, 2: by rewrite (mule_lt0_lt0 Heqx_lt_0 Heqx_lt_1).
-   Qed.*)
-
-Lemma muleA (R: realDomainType) (a b c: \bar R): a * (b * c) = a * b * c.
-Proof.
-wlog: a b c / 0 < a => [h|a0].
-   case/boolP: (a == 0)=>[/eqP->|]; first by rewrite 3!mul0e.
-   move=>/Order.TotalTheory.lt_total=>/orP[a0|]; last by apply h.
-   by apply (inv_inj oppeK); rewrite -!mulNe; apply h; rewrite oppe_gt0.
-wlog: a b c a0 / 0 < b => [h|b0].
-   case/boolP: (b == 0)=>[/eqP->|]; first by rewrite mul0e mule0 mul0e.
-   move=>/Order.TotalTheory.lt_total=>/orP[b0|]; last by apply h.
-   by apply (inv_inj oppeK); rewrite -muleN -mulNe -mulNe -muleN; apply h=>//; rewrite oppe_gt0.
-wlog: a b c a0 b0 / 0 < c => [h|c0].
-   case/boolP: (c == 0)=>[/eqP->|]; first by rewrite 3!mule0.
-   move=>/Order.TotalTheory.lt_total=>/orP[c0|]; last by apply h.
-   by apply (inv_inj oppeK); rewrite -!muleN ; apply h=>//; rewrite oppe_gt0.
-case: a a0=>// [a a0 | _].
-   case: b b0=>// [b b0 | _].
-      case: c c0=>// [c c0 | _].
-         by rewrite /mule/mule_subdef mulrA.
-      repeat rewrite [_* +oo]muleC gt0_mulye//.
-      by apply mule_gt0.
-   by rewrite gt0_mulye// [_* +oo]muleC gt0_mulye// gt0_mulye.
-by rewrite !gt0_mulye//; apply mule_gt0.
 Qed.
 


### PR DESCRIPTION
Updates convex.v and preliminaries.v so as to rely on infotheo. Solves issue #17, replaces PR #18. On a side note, muleA now compiles almost instantly. Some of the content of this PR could be moved to infotheo.